### PR TITLE
support profile, article, and book open graph type properties

### DIFF
--- a/src/meta/buildTags.jsx
+++ b/src/meta/buildTags.jsx
@@ -62,6 +62,68 @@ const buildTags = (config) => {
 
     if (config.openGraph.type) {
       tagsToRender.push(<meta key="og:type" property="og:type" content={config.openGraph.type} />);
+
+      if (config.openGraph.type == 'profile' && config.openGraph.profile) {
+        if (config.openGraph.profile.first_name) {
+          tagsToRender.push(<meta key="profile:first_name" property="profile:first_name" content={config.openGraph.profile.first_name} />);
+        }
+
+        if (config.openGraph.profile.last_name) {
+          tagsToRender.push(<meta key="profile:last_name" property="profile:last_name" content={config.openGraph.profile.last_name} />);
+        }
+
+        if (config.openGraph.profile.username) {
+          tagsToRender.push(<meta key="profile:username" property="profile:username" content={config.openGraph.profile.username} />);
+        }
+
+        if (config.openGraph.profile.gender) {
+          tagsToRender.push(<meta key="profile:gender" property="profile:gender" content={config.openGraph.profile.gender} />);
+        }
+      }
+
+      if (config.openGraph.type == 'book' && config.openGraph.book) {
+        if (config.openGraph.book.author) {
+          tagsToRender.push(<meta key="book:author" property="book:author" content={config.openGraph.book.author} />);
+        }
+
+        if (config.openGraph.book.isbn) {
+          tagsToRender.push(<meta key="book:isbn" property="book:isbn" content={config.openGraph.book.isbn} />);
+        }
+
+        if (config.openGraph.book.release_date) {
+          tagsToRender.push(<meta key="book:release_date" property="book:release_date" content={config.openGraph.book.release_date} />);
+        }
+
+        if (config.openGraph.book.tag) {
+          tagsToRender.push(<meta key="book:tag" property="book:tag" content={config.openGraph.book.tag} />);
+        }
+      }
+
+      if (config.openGraph.type == 'article' && config.openGraph.article) {
+        if (config.openGraph.article.published_time) {
+          tagsToRender.push(<meta key="article:published_time" property="article:published_time" content={config.openGraph.article.published_time} />);
+        }
+
+        if (config.openGraph.article.modified_time) {
+          tagsToRender.push(<meta key="article:modified_time" property="article:modified_time" content={config.openGraph.article.modified_time} />);
+        }
+
+        if (config.openGraph.article.expiration_time) {
+          tagsToRender.push(<meta key="article:expiration_time" property="article:expiration_time" content={config.openGraph.article.expiration_time} />);
+        }
+
+        if (config.openGraph.article.author) {
+          tagsToRender.push(<meta key="article:author" property="article:author" content={config.openGraph.article.author} />);
+        }
+
+        if (config.openGraph.article.section) {
+          tagsToRender.push(<meta key="article:section" property="article:section" content={config.openGraph.article.section} />);
+        }
+
+        if (config.openGraph.article.tag) {
+          tagsToRender.push(<meta key="article:tag" property="article:tag" content={config.openGraph.article.tag} />);
+        }
+      }
     }
 
     if (config.openGraph.title) {

--- a/src/meta/buildTags.jsx
+++ b/src/meta/buildTags.jsx
@@ -82,8 +82,12 @@ const buildTags = (config) => {
       }
 
       if (config.openGraph.type == 'book' && config.openGraph.book) {
-        if (config.openGraph.book.author) {
-          tagsToRender.push(<meta key="book:author" property="book:author" content={config.openGraph.book.author} />);
+        if (config.openGraph.book.author && config.openGraph.book.author.length) {
+          config.openGraph.book.author.forEach((author, index) => {
+            tagsToRender.push(
+              <meta key={`book:author:0${index}`} property="book:author" content={author} />,
+            );
+          });
         }
 
         if (config.openGraph.book.isbn) {
@@ -94,8 +98,12 @@ const buildTags = (config) => {
           tagsToRender.push(<meta key="book:release_date" property="book:release_date" content={config.openGraph.book.release_date} />);
         }
 
-        if (config.openGraph.book.tag) {
-          tagsToRender.push(<meta key="book:tag" property="book:tag" content={config.openGraph.book.tag} />);
+        if (config.openGraph.book.tag && config.openGraph.book.tag.length) {
+          config.openGraph.book.tag.forEach((tag, index) => {
+            tagsToRender.push(
+              <meta key={`book:tag:0${index}`} property="book:tag" content={tag} />,
+            );
+          });
         }
       }
 
@@ -112,16 +120,24 @@ const buildTags = (config) => {
           tagsToRender.push(<meta key="article:expiration_time" property="article:expiration_time" content={config.openGraph.article.expiration_time} />);
         }
 
-        if (config.openGraph.article.author) {
-          tagsToRender.push(<meta key="article:author" property="article:author" content={config.openGraph.article.author} />);
+        if (config.openGraph.article.author && config.openGraph.article.author.length) {
+          config.openGraph.article.author.forEach((author, index) => {
+            tagsToRender.push(
+              <meta key={`article:author:0${index}`} property="article:author" content={author} />,
+            );
+          });
         }
 
         if (config.openGraph.article.section) {
           tagsToRender.push(<meta key="article:section" property="article:section" content={config.openGraph.article.section} />);
         }
 
-        if (config.openGraph.article.tag) {
-          tagsToRender.push(<meta key="article:tag" property="article:tag" content={config.openGraph.article.tag} />);
+        if (config.openGraph.article.tag && config.openGraph.article.tag.length) {
+          config.openGraph.article.tag.forEach((tag, index) => {
+            tagsToRender.push(
+              <meta key={`article:tag:0${index}`} property="article:tag" content={tag} />,
+            );
+          });
         }
       }
     }


### PR DESCRIPTION
following documentation/guidelines here http://ogp.me/ this should allow the use of these different properties available for a few different open graph types.

let me know what you think?

example config of a profile page passed to NextSeo component:
`
{title: 'my page title',  
desciption: 'my page description',  
noindex: false,
openGraph: {
      url: 'http://mypageurl.com',
      type: 'profile',
      profile: {
             first_name: 'John',
             last_name: 'Smith',
             username: 'jsmith123',
            gender: 'male'
      },
      images: [
               {
                    url: 'link to profile image..'
               }
      ],
      title: 'open graph title',
      description: 'open graph description'
   }
}
`