### PR TITLE
Add JSON-LD Local Business

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,8 +421,8 @@ Local business is supported with a sub-set of properties.
     addressCountry: 'US',
   }}
   geo={{
-    latitude: 37.293058,
-    longitude: -121.988331,
+    latitude: '37.293058',
+    longitude: '-121.988331',
   }}
   images={[
     'https://example.com/photos/1x1/photo.jpg',
@@ -454,7 +454,7 @@ Local business is supported with a sub-set of properties.
 | `geo`           | Geographic coordinates of the business.                                       |
 | `geo.latitude`  | The latitude of the business location                                         |
 | `geo.longitude` | The longitude of the business location                                        |
-| `image`         | An image or images of the business.                                           |
+| `images`        | An image or images of the business.                                           |
 | `telephone`     | A business phone number meant to be the primary contact method for customers. |
 | `url`           | The fully-qualified URL of the specific business location.                    |
 

--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ export default () => (
 
 Local business is supported with a sub-set of properties.
 
-````jsx
+```jsx
 <LocalBusinessJsonLd
   type="Store"
   id="http://davesdeptstore.example.com"
@@ -602,6 +602,7 @@ Local business is supported with a sub-set of properties.
     'https://example.com/photos/16x9/photo.jpg',
   ]}
 />
+```
 
 **Required properties**
 
@@ -619,15 +620,15 @@ Local business is supported with a sub-set of properties.
 
 **Supported properties**
 
-| Property        | Info                                                                          |
-| --------------- | ----------------------------------------------------------------------------- |
-| `description`   | Description of the business location                                          |
-| `geo`           | Geographic coordinates of the business.                                       |
-| `geo.latitude`  | The latitude of the business location                                         |
-| `geo.longitude` | The longitude of the business location                                        |
-| `images`        | An image or images of the business.                                           |
-| `telephone`     | A business phone number meant to be the primary contact method for customers. |
-| `url`           | The fully-qualified URL of the specific business location.                    |
+| Property        | Info                                                                                |
+| --------------- | ----------------------------------------------------------------------------------- |
+| `description`   | Description of the business location                                                |
+| `geo`           | Geographic coordinates of the business.                                             |
+| `geo.latitude`  | The latitude of the business location                                               |
+| `geo.longitude` | The longitude of the business location                                              |
+| `images`        | An image or images of the business. Required for valid markup depending on the type |
+| `telephone`     | A business phone number meant to be the primary contact method for customers.       |
+| `url`           | The fully-qualified URL of the specific business location.                          |
 
 ### Logo
 
@@ -644,7 +645,7 @@ export default () => (
     />
   </>
 );
-````
+```
 
 | Property | Info                                                                                                                                      |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -322,6 +322,8 @@ Below you will find a very basic page implementing each of the available JSON-LD
 - [Article](#article)
 - [Blog](#blog)
 - [Course](#course)
+- [Local Business](#local-business)
+- [Product](#product)
 - [Social Profile](#social-profile)
 
 More to follow very, very soon!
@@ -398,6 +400,63 @@ export default () => (
   </>
 );
 ```
+
+### Local Business
+
+Local business is supported with a sub-set of properties.
+
+```jsx
+<LocalBusinessJsonLd
+  type="Store"
+  id="http://davesdeptstore.example.com"
+  name="Dave's Department Store"
+  description="Dave's latest department store in San Jose, now open"
+  url="http://www.example.com/store-locator/sl/San-Jose-Westgate-Store/1427"
+  telephone="+14088717984"
+  address={{
+    streetAddress: '1600 Saratoga Ave',
+    addressLocality: 'San Jose',
+    addressRegion: 'CA',
+    postalCode: '95129',
+    addressCountry: 'US',
+  }}
+  geo={{
+    latitude: 37.293058,
+    longitude: -121.988331,
+  }}
+  images={[
+    'https://example.com/photos/1x1/photo.jpg',
+    'https://example.com/photos/4x3/photo.jpg',
+    'https://example.com/photos/16x9/photo.jpg',
+  ]}
+/>
+```
+
+**Required properties**
+
+| Property                  | Info                                                                       |
+| ------------------------- | -------------------------------------------------------------------------- |
+| `@id`                     | Globally unique ID of the specific business location in the form of a URL. |
+| `type`                    | LocalBusiness or any sub-type                                              |
+| `address`                 | Address of the specific business location                                  |
+| `address.addressCountry`  | The 2-letter ISO 3166-1 alpha-2 country code                               |
+| `address.addressLocality` | City                                                                       |
+| `address.addressRegion`   | State or province, if applicable.                                          |
+| `address.postalCode`      | Postal or zip code.                                                        |
+| `address.streetAddress`   | Street number, street name, and unit number.                               |
+| `name`                    | Business name.                                                             |
+
+**Supported properties**
+
+| Property        | Info                                                                          |
+| --------------- | ----------------------------------------------------------------------------- |
+| `description`   | Description of the business location                                          |
+| `geo`           | Geographic coordinates of the business.                                       |
+| `geo.latitude`  | The latitude of the business location                                         |
+| `geo.longitude` | The longitude of the business location                                        |
+| `image`         | An image or images of the business.                                           |
+| `telephone`     | A business phone number meant to be the primary contact method for customers. |
+| `url`           | The fully-qualified URL of the specific business location.                    |
 
 ### Product
 

--- a/e2e/cypress/e2e/jsonld.spec.js
+++ b/e2e/cypress/e2e/jsonld.spec.js
@@ -174,7 +174,7 @@ describe('Validates JSON-LD For:', () => {
     cy.get('head script[type="application/ld+json"]')
       .should('have.length', expectedJSONResults)
       .then(tags => {
-        const jsonLD = JSON.parse(tags[3].innerHTML);
+        const jsonLD = JSON.parse(tags[4].innerHTML);
         assertSchema(schemas)('Logo', '1.0.0')(jsonLD);
       });
   });
@@ -184,7 +184,7 @@ describe('Validates JSON-LD For:', () => {
     cy.get('head script[type="application/ld+json"]')
       .should('have.length', expectedJSONResults)
       .then(tags => {
-        const jsonLD = JSON.parse(tags[3].innerHTML);
+        const jsonLD = JSON.parse(tags[4].innerHTML);
         expect(jsonLD).to.deep.equal({
           '@context': 'http://schema.org',
           '@type': 'Organization',
@@ -199,7 +199,7 @@ describe('Validates JSON-LD For:', () => {
     cy.get('head script[type="application/ld+json"]')
       .should('have.length', expectedJSONResults)
       .then(tags => {
-        const jsonLD = JSON.parse(tags[4].innerHTML);
+        const jsonLD = JSON.parse(tags[5].innerHTML);
         assertSchema(schemas)('Product', '1.0.0')(jsonLD);
       });
   });
@@ -209,7 +209,7 @@ describe('Validates JSON-LD For:', () => {
     cy.get('head script[type="application/ld+json"]')
       .should('have.length', expectedJSONResults)
       .then(tags => {
-        const jsonLD = JSON.parse(tags[4].innerHTML);
+        const jsonLD = JSON.parse(tags[5].innerHTML);
         expect(jsonLD).to.deep.equal({
           '@context': 'http://schema.org/',
           '@type': 'Product',
@@ -268,7 +268,7 @@ describe('Validates JSON-LD For:', () => {
     cy.get('head script[type="application/ld+json"]')
       .should('have.length', expectedJSONResults)
       .then(tags => {
-        const jsonLD = JSON.parse(tags[5].innerHTML);
+        const jsonLD = JSON.parse(tags[6].innerHTML);
         assertSchema(schemas)('Social Profile', '1.0.0')(jsonLD);
       });
   });
@@ -278,7 +278,7 @@ describe('Validates JSON-LD For:', () => {
     cy.get('head script[type="application/ld+json"]')
       .should('have.length', expectedJSONResults)
       .then(tags => {
-        const jsonLD = JSON.parse(tags[5].innerHTML);
+        const jsonLD = JSON.parse(tags[6].innerHTML);
         expect(jsonLD).to.deep.equal({
           '@context': 'http://schema.org',
           '@type': 'Person',

--- a/e2e/cypress/e2e/jsonld.spec.js
+++ b/e2e/cypress/e2e/jsonld.spec.js
@@ -1,7 +1,7 @@
 import { assertSchema } from '@cypress/schema-tools';
 import schemas from '../schemas';
 
-const expectedJSONResults = 5;
+const expectedJSONResults = 6;
 
 describe('Validates JSON-LD For:', () => {
   it('Article', () => {
@@ -122,12 +122,59 @@ describe('Validates JSON-LD For:', () => {
       });
   });
 
-  it('Product', () => {
+  it('Local Business', () => {
     cy.visit('http://localhost:3000/jsonld');
     cy.get('head script[type="application/ld+json"]')
       .should('have.length', expectedJSONResults)
       .then(tags => {
         const jsonLD = JSON.parse(tags[3].innerHTML);
+        assertSchema(schemas)('Local Business', '1.0.0')(jsonLD);
+      });
+  });
+
+  it('Local Business', () => {
+    cy.visit('http://localhost:3000/jsonld');
+    cy.get('head script[type="application/ld+json"]')
+      .should('have.length', expectedJSONResults)
+      .then(tags => {
+        const jsonLD = JSON.parse(tags[3].innerHTML);
+        expect(jsonLD).to.deep.equal({
+          '@context': 'http://schema.org',
+          '@type': 'Store',
+          '@id': 'http://davesdeptstore.example.com',
+          name: "Dave's Department Store",
+          description: "Dave's latest department store in San Jose, now open",
+          url:
+            'http://www.example.com/store-locator/sl/San-Jose-Westgate-Store/1427',
+          telephone: '+14088717984',
+          address: {
+            '@type': 'PostalAddress',
+            streetAddress: '1600 Saratoga Ave',
+            addressLocality: 'San Jose',
+            addressRegion: 'CA',
+            postalCode: '95129',
+            addressCountry: 'US',
+          },
+          geo: {
+            '@type': 'GeoCoordinates',
+            latitude: '37.293058',
+            longitude: '-121.988331',
+          },
+          image: [
+            'https://example.com/photos/1x1/photo.jpg',
+            'https://example.com/photos/4x3/photo.jpg',
+            'https://example.com/photos/16x9/photo.jpg',
+          ],
+        });
+      });
+  });
+
+  it('Product', () => {
+    cy.visit('http://localhost:3000/jsonld');
+    cy.get('head script[type="application/ld+json"]')
+      .should('have.length', expectedJSONResults)
+      .then(tags => {
+        const jsonLD = JSON.parse(tags[4].innerHTML);
         assertSchema(schemas)('Product', '1.0.0')(jsonLD);
       });
   });
@@ -137,7 +184,7 @@ describe('Validates JSON-LD For:', () => {
     cy.get('head script[type="application/ld+json"]')
       .should('have.length', expectedJSONResults)
       .then(tags => {
-        const jsonLD = JSON.parse(tags[3].innerHTML);
+        const jsonLD = JSON.parse(tags[4].innerHTML);
         expect(jsonLD).to.deep.equal({
           '@context': 'http://schema.org/',
           '@type': 'Product',
@@ -196,7 +243,7 @@ describe('Validates JSON-LD For:', () => {
     cy.get('head script[type="application/ld+json"]')
       .should('have.length', expectedJSONResults)
       .then(tags => {
-        const jsonLD = JSON.parse(tags[4].innerHTML);
+        const jsonLD = JSON.parse(tags[5].innerHTML);
         assertSchema(schemas)('Social Profile', '1.0.0')(jsonLD);
       });
   });
@@ -206,7 +253,7 @@ describe('Validates JSON-LD For:', () => {
     cy.get('head script[type="application/ld+json"]')
       .should('have.length', expectedJSONResults)
       .then(tags => {
-        const jsonLD = JSON.parse(tags[4].innerHTML);
+        const jsonLD = JSON.parse(tags[5].innerHTML);
         expect(jsonLD).to.deep.equal({
           '@context': 'http://schema.org',
           '@type': 'Person',

--- a/e2e/cypress/e2e/jsonld.spec.js
+++ b/e2e/cypress/e2e/jsonld.spec.js
@@ -1,7 +1,7 @@
 import { assertSchema } from '@cypress/schema-tools';
 import schemas from '../schemas';
 
-const expectedJSONResults = 6;
+const expectedJSONResults = 7;
 
 describe('Validates JSON-LD For:', () => {
   it('Article', () => {

--- a/e2e/cypress/schemas/index.js
+++ b/e2e/cypress/schemas/index.js
@@ -1,14 +1,17 @@
 import { combineSchemas } from '@cypress/schema-tools';
-import courseVersions from './course-schema';
+
 import articleVersions from './article-schema';
 import blogVersions from './blog-schema';
+import courseVersions from './course-schema';
+import localBusiness from './local-business-schema';
 import productVersions from './product-schema';
 import socialProfileVersions from './social-profile-schema';
 
 const schemas = combineSchemas(
-  courseVersions,
   articleVersions,
   blogVersions,
+  courseVersions,
+  localBusiness,
   productVersions,
   socialProfileVersions,
 );

--- a/e2e/cypress/schemas/local-business-schema.js
+++ b/e2e/cypress/schemas/local-business-schema.js
@@ -1,0 +1,136 @@
+import { versionSchemas } from '@cypress/schema-tools';
+
+const socialProfile100 = {
+  version: {
+    major: 1,
+    minor: 0,
+    patch: 0,
+  },
+  schema: {
+    type: 'object',
+    title: 'Local Business',
+    description:
+      'An example schema describing JSON-LD for type: Local Business',
+    properties: {
+      '@context': {
+        type: 'string',
+        description: 'Schema.org context',
+      },
+      '@type': {
+        type: 'string',
+        description:
+          'Any more specific type supported by Local Business https://schema.org/LocalBusiness',
+      },
+      '@id': {
+        type: 'string',
+        description:
+          'Globally unique ID of the specific business location in the form of a URL. The ID should be stable and unchanging over time. Google Search treats the URL as an opaque string and it does not have to be a working link. If the business has multiple locations, make sure the @id is unique for each location.',
+      },
+      name: {
+        type: 'string',
+        description: 'The name of the person or organisation.',
+      },
+      description: {
+        type: 'string',
+        description: 'Description for the local business.',
+      },
+      url: {
+        type: 'string',
+        description:
+          'The fully-qualified URL of the specific business location. Unlike the @id property, this URL property should be a working link.',
+      },
+      telephone: {
+        type: 'string',
+        description:
+          'A business phone number meant to be the primary contact method for customers. Be sure to include the country code and area code in the phone number.',
+      },
+      image: {
+        type: 'array',
+        items: {
+          type: 'string',
+        },
+        description: "Array of image URL's",
+      },
+      address: {
+        type: 'object',
+        description: "Array of social profile URL's",
+        properties: {
+          '@type': {
+            type: 'string',
+            description: 'JSON-LD type: PostalAddress',
+          },
+          streetAddress: {
+            type: 'string',
+            description: 'Street number, street name, and unit number',
+          },
+          addressLocality: {
+            type: 'string',
+            description: 'City',
+          },
+          addressRegion: {
+            type: 'string',
+            description: 'State or province, if applicable.',
+          },
+          postalCode: {
+            type: 'string',
+            description: 'Postal or zip code.',
+          },
+          addressCountry: {
+            type: 'string',
+            description: 'The 2-letter ISO 3166-1 alpha-2 country code',
+          },
+        },
+      },
+      geo: {
+        type: 'object',
+        description: "Array of social profile URL's",
+        properties: {
+          '@type': {
+            type: 'string',
+            description: 'JSON-LD type: GeoCoordinates',
+          },
+          latitude: {
+            type: 'string',
+            description: 'The latitude of the business location.',
+          },
+          longitude: {
+            type: 'string',
+            description: 'The longitude of the business location.',
+          },
+        },
+      },
+    },
+    required: true,
+    additionalProperties: false,
+  },
+  example: {
+    '@context': 'http://schema.org',
+    '@type': 'Store',
+    image: [
+      'https://example.com/photos/1x1/photo.jpg',
+      'https://example.com/photos/4x3/photo.jpg',
+      'https://example.com/photos/16x9/photo.jpg',
+    ],
+    '@id': 'http://davesdeptstore.example.com',
+    name: "Dave's Department Store",
+    description: 'Some form of description',
+    address: {
+      '@type': 'PostalAddress',
+      streetAddress: '1600 Saratoga Ave',
+      addressLocality: 'San Jose',
+      addressRegion: 'CA',
+      postalCode: '95129',
+      addressCountry: 'US',
+    },
+    geo: {
+      '@type': 'GeoCoordinates',
+      latitude: 37.293058,
+      longitude: -121.988331,
+    },
+    url: 'http://www.example.com/store-locator/sl/San-Jose-Westgate-Store/1427',
+    telephone: '+14088717984',
+  },
+};
+
+const socialProfile = versionSchemas(socialProfile100);
+export default socialProfile;

--- a/e2e/cypress/schemas/local-business-schema.js
+++ b/e2e/cypress/schemas/local-business-schema.js
@@ -124,8 +124,8 @@ const socialProfile100 = {
     },
     geo: {
       '@type': 'GeoCoordinates',
-      latitude: 37.293058,
-      longitude: -121.988331,
+      latitude: '37.293058',
+      longitude: '-121.988331',
     },
     url: 'http://www.example.com/store-locator/sl/San-Jose-Westgate-Store/1427',
     telephone: '+14088717984',

--- a/e2e/pages/jsonld.jsx
+++ b/e2e/pages/jsonld.jsx
@@ -64,8 +64,8 @@ export default () => (
         addressCountry: 'US',
       }}
       geo={{
-        latitude: 37.293058,
-        longitude: -121.988331,
+        latitude: '37.293058',
+        longitude: '-121.988331',
       }}
       images={[
         'https://example.com/photos/1x1/photo.jpg',

--- a/e2e/pages/jsonld.jsx
+++ b/e2e/pages/jsonld.jsx
@@ -3,6 +3,7 @@ import {
   ArticleJsonLd,
   BlogJsonLd,
   CourseJsonLd,
+  LocalBusinessJsonLd,
   ProductJsonLd,
   SocialProfileJsonLd,
 } from '../../dist';
@@ -46,6 +47,31 @@ export default () => (
       providerName="Course Provider"
       providerUrl="https//www.example.com/provider"
       description="Course description goes right here"
+    />
+
+    <LocalBusinessJsonLd
+      type="Store"
+      id="http://davesdeptstore.example.com"
+      name="Dave's Department Store"
+      description="Dave's latest department store in San Jose, now open"
+      url="http://www.example.com/store-locator/sl/San-Jose-Westgate-Store/1427"
+      telephone="+14088717984"
+      address={{
+        streetAddress: '1600 Saratoga Ave',
+        addressLocality: 'San Jose',
+        addressRegion: 'CA',
+        postalCode: '95129',
+        addressCountry: 'US',
+      }}
+      geo={{
+        latitude: 37.293058,
+        longitude: -121.988331,
+      }}
+      images={[
+        'https://example.com/photos/1x1/photo.jpg',
+        'https://example.com/photos/4x3/photo.jpg',
+        'https://example.com/photos/16x9/photo.jpg',
+      ]}
     />
 
     <ProductJsonLd

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import DefaultSeo from './meta/defaultSEO';
 import ArticleJsonLd from './jsonld/article';
 import BlogJsonLd from './jsonld/blog';
 import CourseJsonLd from './jsonld/course';
+import LocalBusinessJsonLd from './jsonld/localBusiness';
 import ProductJsonLd from './jsonld/product';
 import SocialProfileJsonLd from './jsonld/socialProfile';
 
@@ -10,6 +11,7 @@ export {
   ArticleJsonLd,
   BlogJsonLd,
   CourseJsonLd,
+  LocalBusinessJsonLd,
   ProductJsonLd,
   SocialProfileJsonLd,
 };

--- a/src/jsonld/localBusiness.jsx
+++ b/src/jsonld/localBusiness.jsx
@@ -5,7 +5,7 @@ import Head from 'next/head';
 import markup from '../utils/markup';
 
 const buildImages = images =>
-  images.length ? `"image": [${images.map(image => `"${image}"`)}]` : '';
+  images.length ? `"image": [${images.map(image => `"${image}"`)}],` : '';
 
 const buildGeo = geo => `
   "geo": {
@@ -47,13 +47,13 @@ const LocalBusinessJsonLd = ({
     "@context": "http://schema.org",
     "@type": "${type}",
     "@id": "${id}",
-    "name": "${name}",
     ${description ? `"description": "${description}",` : ''}
     ${url ? `"url": "${url}",` : ''}
     ${telephone ? `"telephone": "${telephone}",` : ''}
     ${buildAddress(address)}
     ${geo ? `${buildGeo(geo)}` : ''}
     ${buildImages(images)} 
+    "name": "${name}"
   }`;
 
   return (

--- a/src/jsonld/localBusiness.jsx
+++ b/src/jsonld/localBusiness.jsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import Head from 'next/head';
+
+import markup from '../utils/markup';
+
+const buildImages = images =>
+  images.length ? `"image": [${images.map(image => `"${image}"`)}]` : '';
+
+const buildGeo = geo => `
+  "geo": {
+    "@type": "GeoCoordinates",
+    "latitude": "${geo.latitude}",
+    "longitude": "${geo.longitude}"
+  },
+`;
+
+const buildAddress = address => `
+  "address": {
+    "@type": "PostalAddress",
+    "streetAddress": "${address.streetAddress}",
+    "addressLocality": "${address.addressLocality}",
+    ${
+      address.addressRegion
+        ? `"addressRegion": "${address.addressRegion}",`
+        : ''
+    }
+    "postalCode": "${address.postalCode}",
+    "addressCountry": "${address.addressCountry}"
+  },
+`;
+
+const LocalBusinessJsonLd = ({
+  type,
+  id,
+  name,
+  description,
+  url,
+  telephone,
+  address,
+  geo,
+  images,
+}) => {
+  // NOTE: Images has no trailing , as it would make the content invalid
+  // If you add more properties update buildImages
+  const jslonld = `{
+    "@context": "http://schema.org",
+    "@type": "${type}",
+    "@id": "${id}",
+    "name": "${name}",
+    ${description ? `"description": "${description}",` : ''}
+    ${url ? `"url": "${url}",` : ''}
+    ${telephone ? `"telephone": "${telephone}",` : ''}
+    ${buildAddress(address)}
+    ${geo ? `${buildGeo(geo)}` : ''}
+    ${buildImages(images)} 
+  }`;
+
+  return (
+    <Head>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={markup(jslonld)}
+        key="jsonld-local-business"
+      />
+    </Head>
+  );
+};
+
+LocalBusinessJsonLd.defaultProps = {
+  type: 'LocalBusiness',
+  description: null,
+  url: null,
+  telephone: null,
+  images: [],
+  geo: null,
+};
+
+LocalBusinessJsonLd.propTypes = {
+  type: PropTypes.string,
+  id: PropTypes.string.isRequired,
+  name: PropTypes.string.isRequired,
+  description: PropTypes.string,
+  url: PropTypes.string,
+  telephone: PropTypes.string,
+  address: PropTypes.shape({
+    streetAddress: PropTypes.string.isRequired,
+    addressLocality: PropTypes.string.isRequired,
+    addressRegion: PropTypes.string,
+    postalCode: PropTypes.string.isRequired,
+    addressCountry: PropTypes.string.isRequired,
+  }).isRequired,
+  geo: PropTypes.shape({
+    latitude: PropTypes.string.isRequired,
+    longitude: PropTypes.string.isRequired,
+  }),
+  images: PropTypes.arrayOf(PropTypes.string),
+};
+
+export default LocalBusinessJsonLd;


### PR DESCRIPTION
This adds support for[ basic local business](https://developers.google.com/search/docs/data-types/local-business) properties as outlined in the readme. 

By default the type will be LocalBusiness but users can provide any valid sub-type as per the documentation. 

Images code was taken from product but not turned into a generic helper. This felt like it could be reused but leaving them separate allowed for better isolation. Happy to change this and move buildImages to a common builders file with tests. 

Additional changes to reorder imports/exports alphabetically and add the missing product link in the readme are included in the same commit.   

Fixes #23 