### PR TITLE
Fix link issue with Article

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,7 +570,7 @@ Google has excellent content on JSON-LD -> [HERE](https://developers.google.com/
 
 Below you will find a very basic page implementing each of the available JSON-LD types:
 
-- [Article](#article)
+- [Article](#article-1)
 - [Breadcrumb](#breadcrumb)
 - [Blog](#blog)
 - [Course](#course)


### PR DESCRIPTION
Due to both OpenGraph and JSON-LD having `Article` links when you click the article link in JSON-LD it routes to the Open Graph `Article`. This slight update fixes the issue.