### PR TITLE
property='fb:app_id' should be used instead of name='fb:app_id'

### DIFF
--- a/src/meta/buildTags.jsx
+++ b/src/meta/buildTags.jsx
@@ -101,7 +101,7 @@ const buildTags = config => {
       tagsToRender.push(
         <meta
           key="fb:app_id"
-          name="fb:app_id"
+          property="fb:app_id"
           content={config.facebook.appId}
         />,
       );


### PR DESCRIPTION
According to [Facebook debug tool](https://developers.facebook.com/tools/debug)
`property='fb:app_id'` should be used instead of `name='fb:app_id'` in meta tag