### PR TITLE
 property='fb:app_id' should be used instead of name='fb:app_id'

### DIFF
--- a/e2e/cypress/e2e/seo.spec.js
+++ b/e2e/cypress/e2e/seo.spec.js
@@ -96,7 +96,7 @@ describe('SEO Meta', () => {
       'content',
       'SiteName A',
     );
-    cy.get('head meta[name="fb:app_id"]').should(
+    cy.get('head meta[property="fb:app_id"]').should(
       'have.attr',
       'content',
       '1234567890',
@@ -214,7 +214,7 @@ describe('SEO Meta', () => {
       'content',
       'SiteName B',
     );
-    cy.get('head meta[name="fb:app_id"]').should(
+    cy.get('head meta[property="fb:app_id"]').should(
       'have.attr',
       'content',
       '987654321',

--- a/src/meta/__tests__/__snapshots__/buildTags.spec.jsx.snap
+++ b/src/meta/__tests__/__snapshots__/buildTags.spec.jsx.snap
@@ -355,7 +355,7 @@ exports[`renders correctly 1`] = `
   />
   <meta
     content="1234567890"
-    name="fb:app_id"
+    property="fb:app_id"
   />
   <meta
     content="https://www.url.ie"

--- a/src/meta/__tests__/buildTags.spec.jsx
+++ b/src/meta/__tests__/buildTags.spec.jsx
@@ -64,7 +64,7 @@ it('returns full array for default seo object', () => {
   const twitterCard = container.querySelectorAll(
     'meta[content="summary_large_image"]',
   );
-  const facebookAppId = container.querySelectorAll('meta[name="fb:app_id"]');
+  const facebookAppId = container.querySelectorAll('meta[property="fb:app_id"]');
   const twitterCardTag = container.querySelectorAll(
     'meta[name="twitter:card"]',
   );

--- a/src/meta/buildTags.jsx
+++ b/src/meta/buildTags.jsx
@@ -101,7 +101,7 @@ const buildTags = config => {
       tagsToRender.push(
         <meta
           key="fb:app_id"
-          name="fb:app_id"
+          property="fb:app_id"
           content={config.facebook.appId}
         />,
       );


### PR DESCRIPTION
Close #43, According to facebook debug tool
`property='fb:app_id'` should be used instead of `name='fb:app_id'`