### PR TITLE
opengraph inherit from main config: WIP

### DIFF
--- a/src/meta/buildTags.jsx
+++ b/src/meta/buildTags.jsx
@@ -393,6 +393,17 @@ const buildTags = config => {
         />,
       );
     }
+  } else {
+    tagsToRender.push(
+      <meta key="og:type" property="og:type" content="website" />,
+      <meta key="og:title" property="og:title" content={config.title} />,
+      <meta
+        key="og:description"
+        property="og:description"
+        content={config.description}
+      />,
+      <meta key="og:url" property="og:url" content={config.canonical} />,
+    );
   }
 
   if (config.canonical) {


### PR DESCRIPTION
fixes #15 

if open graph is not provided in the default config, it will inherit the main config values. It will inherit

- [x] title
- [x] description
- [x] conanical -> url
- [x] include default type as `website`

WIP: how to test this, which will involve changing how all the default tags are tested in cypress right now.