### PR TITLE
Fix scoping issue of `defaults` object in `buildTags.jsx`

### DIFF
--- a/src/meta/__tests__/__snapshots__/buildTags.spec.jsx.snap
+++ b/src/meta/__tests__/__snapshots__/buildTags.spec.jsx.snap
@@ -3,7 +3,7 @@
 exports[`Article SEO renders correctly 1`] = `
 <div>
   <title>
-    Next SEO | Article Page Title
+    Article Page Title
   </title>
   <meta
     content="index,follow"
@@ -119,7 +119,7 @@ exports[`Article SEO renders correctly 1`] = `
 exports[`Book SEO renders correctly 1`] = `
 <div>
   <title>
-    Next SEO | Book Page Title
+    Book Page Title
   </title>
   <meta
     content="index,follow"
@@ -227,7 +227,7 @@ exports[`Book SEO renders correctly 1`] = `
 exports[`Profile SEO renders correctly 1`] = `
 <div>
   <title>
-    Next SEO | Profile Page Title
+    Profile Page Title
   </title>
   <meta
     content="index,follow"

--- a/src/meta/__tests__/buildTags.spec.jsx
+++ b/src/meta/__tests__/buildTags.spec.jsx
@@ -64,7 +64,9 @@ it('returns full array for default seo object', () => {
   const twitterCard = container.querySelectorAll(
     'meta[content="summary_large_image"]',
   );
-  const facebookAppId = container.querySelectorAll('meta[property="fb:app_id"]');
+  const facebookAppId = container.querySelectorAll(
+    'meta[property="fb:app_id"]',
+  );
   const twitterCardTag = container.querySelectorAll(
     'meta[name="twitter:card"]',
   );
@@ -253,6 +255,21 @@ it('Article SEO renders correctly', () => {
   const tags = buildTags(ArticleSEO);
   const { container } = render(tags);
   expect(container).toMatchSnapshot();
+});
+
+it('Displays the title correctly', () => {
+  const overrideProps = {
+    ...ArticleSEO,
+  };
+  const tags = buildTags(overrideProps);
+  const { container } = render(tags);
+  const title = getByText(
+    container,
+    (content, element) =>
+      element.tagName.toLowerCase() === 'title' &&
+      content.endsWith(ArticleSEO.title),
+  );
+  expect(title.innerHTML).toEqual(ArticleSEO.title);
 });
 
 it('Check article og type meta', () => {

--- a/src/meta/buildTags.jsx
+++ b/src/meta/buildTags.jsx
@@ -1,15 +1,14 @@
 import React from 'react';
 
-const defaults = {
-  templateTitle: null,
-  noindex: false,
-  openGraph: {
-    defaultImageHeight: null,
-    defaultImageWidth: null,
-  },
-};
-
 const buildTags = config => {
+  const defaults = {
+    templateTitle: null,
+    noindex: false,
+    openGraph: {
+      defaultImageHeight: null,
+      defaultImageWidth: null,
+    },
+  };
   const tagsToRender = [];
 
   if (config.titleTemplate) {


### PR DESCRIPTION
The `defaults` object in `buildTags.jsx` was defined in global scope which would cause issues between renders. For example, in our case page A has a `titleTemplate` defined and page B doesn’t. If page B would be rendered _after_ page A, the title would still follow the template because it was served from memory. Was there any particular reason this was defined in global scope?

The wrong behaviour was also visible in your own snapshots, where the title of "Article SEO" would contain the template defined in an earlier test when it shouldn’t, see https://github.com/garmeeh/next-seo/commit/33a0fbd023b02420605937de02aeb2a28fdb3cb6.

This PR addresses the issue by moving the `defaults` object into the scope of the `buildTags()` function. I added an additional test to verify the correct behaviour and updated the existing snapshots accordingly.

Let me know your thoughts on this or if you need me make any other changes!

Props to @adri for helping me trouble-shoot this.