### PR TITLE
Rating and reviews are non-required fields

### DIFF
--- a/src/jsonld/product.tsx
+++ b/src/jsonld/product.tsx
@@ -39,8 +39,8 @@ export interface ProductJsonLdProps {
   images?: string[];
   description?: string;
   brand?: string;
-  reviews: Review[];
-  aggregateRating: AggregateRating;
+  reviews?: Review[];
+  aggregateRating?: AggregateRating;
   offers: Offers;
   sku?: string;
   gtin8?: string;


### PR DESCRIPTION
Rating and aggregated reviews are non-required fields (but recommended) according to Google documentations and looks like it also handled by codebase. 
So I just tuned up a type for component props.

Sometimes you can have a product on your website but you can have no reviews or ratings for products.

![image](https://user-images.githubusercontent.com/301917/65952030-e5c2b880-e449-11e9-96fa-d4ec6b55b8ec.png)

https://developers.google.com/search/docs/data-types/product