### PR TITLE
Opening hours and sameAs support for local business jsonld

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,6 +1029,29 @@ Local business is supported with a sub-set of properties.
     'https://example.com/photos/4x3/photo.jpg',
     'https://example.com/photos/16x9/photo.jpg',
   ]}
+  openingHours={[
+    {
+      opens: '08:00',
+      closes: '23:59',
+      dayOfWeek: [
+        'Monday',
+        'Tuesday',
+        'Wednesday',
+        'Thursday',
+        'Friday',
+        'Saturday',
+      ],
+      validFrom: '2019-12-23',
+      validThrough: '2020-04-02',
+    },
+    {
+      opens: '14:00',
+      closes: '20:00',
+      dayOfWeek: 'Sunday',
+      validFrom: '2019-12-23',
+      validThrough: '2020-04-02',
+    },
+  ]}
 />
 ```
 
@@ -1048,15 +1071,28 @@ Local business is supported with a sub-set of properties.
 
 **Supported properties**
 
-| Property        | Info                                                                                |
-| --------------- | ----------------------------------------------------------------------------------- |
-| `description`   | Description of the business location                                                |
-| `geo`           | Geographic coordinates of the business.                                             |
-| `geo.latitude`  | The latitude of the business location                                               |
-| `geo.longitude` | The longitude of the business location                                              |
-| `images`        | An image or images of the business. Required for valid markup depending on the type |
-| `telephone`     | A business phone number meant to be the primary contact method for customers.       |
-| `url`           | The fully-qualified URL of the specific business location.                          |
+| Property             | Info                                                                                |
+| -------------------- | ----------------------------------------------------------------------------------- |
+| `description`        | Description of the business location                                                |
+| `geo`                | Geographic coordinates of the business.                                             |
+| `geo.latitude`       | The latitude of the business location                                               |
+| `geo.longitude`      | The longitude of the business location                                              |
+| `rating`             | The average rating of business based on multiple ratings or reviews.                |
+| `rating.ratingValue` | The rating for the content.                                                         |
+| `rating.ratingCount` | The count of total number of ratings.                                               |
+| `priceRange`         | The relative price range of the business.                                           |
+| `images`             | An image or images of the business. Required for valid markup depending on the type |
+| `telephone`          | A business phone number meant to be the primary contact method for customers.       |
+| `url`                | The fully-qualified URL of the specific business location.                          |
+| `sameAs`             | An array of URLs that represent this business                                       |
+
+|
+| `openingHours` | Opening hour specification of business. You can provide this as a single object, or an array of objects with the properties below. |
+| `openingHours.opens` | The opening hour of the place or service on the given day(s) of the week. |
+| `openingHours.closes` | The closing hour of the place or service on the given day(s) of the week. |
+| `openingHours.dayOfWeek` | The day of the week for which these opening hours are valid. Can be a string or array of strings. Refer to [DayOfWeek](https://schema.org/DayOfWeek) |
+| `openingHours.validFrom` | The date when the item becomes valid. |
+| `openingHours.validThrough` | The date after when the item is not valid. |
 
 **NOTE:**
 

--- a/cypress/e2e/jsonld.spec.js
+++ b/cypress/e2e/jsonld.spec.js
@@ -197,11 +197,11 @@ describe('Validates JSON-LD For:', () => {
       .should('have.length', expectedJSONResults)
       .then(tags => {
         const jsonLD = JSON.parse(tags[localBusinessLdJsonIndex].innerHTML);
-        assertSchema(schemas)('Local Business', '1.0.0')(jsonLD);
+        assertSchema(schemas)('Local Business', '1.1.0')(jsonLD);
       });
   });
 
-  it('Local Business', () => {
+  it('Local Business Matches', () => {
     cy.visit('http://localhost:3000/jsonld');
     cy.get('head script[type="application/ld+json"]')
       .should('have.length', expectedJSONResults)
@@ -233,6 +233,32 @@ describe('Validates JSON-LD For:', () => {
             'https://example.com/photos/1x1/photo.jpg',
             'https://example.com/photos/4x3/photo.jpg',
             'https://example.com/photos/16x9/photo.jpg',
+          ],
+          sameAs: ['https://thisbusiness.com', 'https://alsothisbusiness.com'],
+          openingHoursSpecification: [
+            {
+              '@type': 'OpeningHoursSpecification',
+              opens: '08:00',
+              closes: '23:59',
+              dayOfWeek: [
+                'Monday',
+                'Tuesday',
+                'Wednesday',
+                'Thursday',
+                'Friday',
+                'Saturday',
+              ],
+              validFrom: '2019-12-23',
+              validThrough: '2020-04-02',
+            },
+            {
+              '@type': 'OpeningHoursSpecification',
+              opens: '14:00',
+              closes: '20:00',
+              dayOfWeek: 'Sunday',
+              validFrom: '2019-12-23',
+              validThrough: '2020-04-02',
+            },
           ],
         });
       });

--- a/cypress/schemas/local-business-schema.js
+++ b/cypress/schemas/local-business-schema.js
@@ -1,9 +1,9 @@
 import { versionSchemas } from '@cypress/schema-tools';
 
-const socialProfile100 = {
+const localBusiness110 = {
   version: {
     major: 1,
-    minor: 0,
+    minor: 1,
     patch: 0,
   },
   schema: {
@@ -99,6 +99,52 @@ const socialProfile100 = {
           },
         },
       },
+      sameAs: {
+        type: 'array',
+        items: {
+          type: 'string',
+        },
+        description: "Array of business URL's",
+      },
+      openingHoursSpecification: {
+        type: 'array',
+        description: 'Opening hour specification for the local business',
+        item: {
+          type: 'object',
+          properties: {
+            '@type': {
+              type: 'string',
+              description: 'JSON-LD type: OpeningHoursSpecification',
+            },
+            opens: {
+              type: 'string',
+              description:
+                'The opening hour of the place or service on the given day(s) of the week.',
+            },
+            closes: {
+              type: 'string',
+              description:
+                'The closing hour of the place or service on the given day(s) of the week.',
+            },
+            dayOfWeek: {
+              type: 'array',
+              items: {
+                type: 'string',
+              },
+              description:
+                'The day of the week for which these opening hours are valid.',
+            },
+            validFrom: {
+              type: 'string',
+              description: 'The date when the item becomes valid.',
+            },
+            validThrough: {
+              type: 'string',
+              description: 'The date after when the item is not valid.',
+            },
+          },
+        },
+      },
     },
     required: true,
     additionalProperties: false,
@@ -129,8 +175,33 @@ const socialProfile100 = {
     },
     url: 'http://www.example.com/store-locator/sl/San-Jose-Westgate-Store/1427',
     telephone: '+14088717984',
+    openingHoursSpecification: [
+      {
+        '@type': 'OpeningHoursSpecification',
+        opens: '08:00',
+        closes: '23:59',
+        dayOfWeek: [
+          'Monday',
+          'Tuesday',
+          'Wednesday',
+          'Thursday',
+          'Friday',
+          'Saturday',
+        ],
+        validFrom: '2019-12-23',
+        validThrough: '2020-04-02',
+      },
+      {
+        '@type': 'OpeningHoursSpecification',
+        opens: '14:00',
+        closes: '20:00',
+        dayOfWeek: 'Sunday',
+        validFrom: '2019-12-23',
+        validThrough: '2020-04-02',
+      },
+    ],
   },
 };
 
-const socialProfile = versionSchemas(socialProfile100);
-export default socialProfile;
+const localBusiness = versionSchemas(localBusiness110);
+export default localBusiness;

--- a/e2e/pages/jsonld.tsx
+++ b/e2e/pages/jsonld.tsx
@@ -101,6 +101,30 @@ export default () => (
         'https://example.com/photos/4x3/photo.jpg',
         'https://example.com/photos/16x9/photo.jpg',
       ]}
+      sameAs={['https://thisbusiness.com', 'https://alsothisbusiness.com']}
+      openingHours={[
+        {
+          opens: '08:00',
+          closes: '23:59',
+          dayOfWeek: [
+            'Monday',
+            'Tuesday',
+            'Wednesday',
+            'Thursday',
+            'Friday',
+            'Saturday',
+          ],
+          validFrom: '2019-12-23',
+          validThrough: '2020-04-02',
+        },
+        {
+          opens: '14:00',
+          closes: '20:00',
+          dayOfWeek: 'Sunday',
+          validFrom: '2019-12-23',
+          validThrough: '2020-04-02',
+        },
+      ]}
     />
 
     <LogoJsonLd

--- a/src/jsonld/localBusiness.tsx
+++ b/src/jsonld/localBusiness.tsx
@@ -22,18 +22,28 @@ type Rating = {
   ratingCount: string;
 };
 
+type OpeningHoursSpecification = {
+  opens: string;
+  closes: string;
+  dayOfWeek: string | string[];
+  validFrom?: string;
+  validThrough?: string;
+};
+
 export interface LocalBusinessJsonLdProps {
   type: string;
   id: string;
   name: string;
   description: string;
-  url: string;
+  url?: string;
   telephone?: string;
   address: Address;
-  geo: Geo;
+  geo?: Geo;
   images: string[];
   rating?: Rating;
   priceRange?: string;
+  sameAs: string[];
+  openingHours?: OpeningHoursSpecification | OpeningHoursSpecification[];
 }
 
 const buildGeo = (geo: Geo) => `
@@ -67,6 +77,25 @@ const buildRating = (rating: Rating) => `
   },
 `;
 
+const buildOpeningHours = (openingHours: OpeningHoursSpecification) => `
+  {
+    "@type": "OpeningHoursSpecification",
+    "opens": "${openingHours.opens}",
+    "closes": "${openingHours.closes}",
+    ${
+      openingHours.dayOfWeek
+        ? `"dayOfWeek": ${formatIfArray(openingHours.dayOfWeek)},`
+        : ''
+    }
+    ${openingHours.validFrom ? `"validFrom": "${openingHours.validFrom}",` : ''}
+    ${
+      openingHours.validThrough
+        ? `"validThrough": "${openingHours.validThrough}"`
+        : ''
+    }
+  }
+`;
+
 const LocalBusinessJsonLd: FC<LocalBusinessJsonLdProps> = ({
   type,
   id,
@@ -79,6 +108,8 @@ const LocalBusinessJsonLd: FC<LocalBusinessJsonLdProps> = ({
   images,
   rating,
   priceRange,
+  sameAs,
+  openingHours,
 }) => {
   const jslonld = `{
     "@context": "http://schema.org",
@@ -92,6 +123,16 @@ const LocalBusinessJsonLd: FC<LocalBusinessJsonLdProps> = ({
     ${rating ? `${buildRating(rating)}` : ''}
     ${priceRange ? `"priceRange": "${priceRange}",` : ''}
     "image":${formatIfArray(images)},
+    ${sameAs ? `"sameAs": [${sameAs.map(url => `"${url}"`)}],` : ''}
+    ${
+      openingHours
+        ? `"openingHoursSpecification": ${
+            Array.isArray(openingHours)
+              ? `[${openingHours.map(hours => `${buildOpeningHours(hours)}`)}]`
+              : buildOpeningHours(openingHours)
+          },`
+        : ''
+    }
     "name": "${name}"
   }`;
 

--- a/src/jsonld/localBusiness.tsx
+++ b/src/jsonld/localBusiness.tsx
@@ -42,7 +42,7 @@ export interface LocalBusinessJsonLdProps {
   images: string[];
   rating?: Rating;
   priceRange?: string;
-  sameAs: string[];
+  sameAs?: string[];
   openingHours?: OpeningHoursSpecification | OpeningHoursSpecification[];
 }
 


### PR DESCRIPTION
## Description of Change(s):

closes https://github.com/garmeeh/next-seo/issues/111

-adds support for openingHoursSpecification (some info here https://developers.google.com/search/docs/data-types/local-business) and sameAs for local business jsonld

-openingHours can be provided as a single object or array of objects as suggested on the google page above

-added missing documentation for rating and pricerange

