### PR TITLE
Allow for multiple copies of json-ld elements by specifying key.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Version One docs can be found [here](https://github.com/garmeeh/next-seo/tree/su
     - [Book](#book)
     - [Profile](#profile)
 - [JSON-LD](#json-ld)
+  - [Handling multiple instances...](#handling-multiple-instances)
   - [Article](#article-1)
   - [Breadcrumb](#breadcrumb)
   - [Blog](#blog)
@@ -826,6 +827,12 @@ Below you will find a very basic page implementing each of the available JSON-LD
 - [News Article](#news-article)
 
 More to follow very, very soon!
+
+#### Handling multiple instances...
+
+If your page's contents requires multiple instances of a given JSON-LD component, simply specify unique `id` properties, and `next-seo` will handle the rest.
+
+This comes in handy for blog rolls, search results, and overview pages.
 
 ### Article
 

--- a/src/jsonld/article.tsx
+++ b/src/jsonld/article.tsx
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import markup from '../utils/markup';
 
 export interface ArticleJsonLdProps {
+  id?: string;
   url: string;
   title: string;
   images: ReadonlyArray<string>;
@@ -16,6 +17,7 @@ export interface ArticleJsonLdProps {
 }
 
 const ArticleJsonLd: FC<ArticleJsonLdProps> = ({
+  id,
   url,
   title,
   images = [],
@@ -59,7 +61,7 @@ const ArticleJsonLd: FC<ArticleJsonLdProps> = ({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={markup(jslonld)}
-        key="jsonld-article"
+        key={`jsonld-article${id ? `-${id}` : ''}`}
       />
     </Head>
   );

--- a/src/jsonld/blog.tsx
+++ b/src/jsonld/blog.tsx
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import markup from '../utils/markup';
 
 export interface BlogJsonLdProps {
+  id?: string;
   url: string;
   title: string;
   images: ReadonlyArray<string>;
@@ -14,6 +15,7 @@ export interface BlogJsonLdProps {
 }
 
 const BlogJsonLd: FC<BlogJsonLdProps> = ({
+  id,
   url,
   title,
   images = [],
@@ -47,7 +49,7 @@ const BlogJsonLd: FC<BlogJsonLdProps> = ({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={markup(jslonld)}
-        key="jsonld-blog"
+        key={`jsonld-blog${id ? `-${id}` : ''}`}
       />
     </Head>
   );

--- a/src/jsonld/breadcrumb.tsx
+++ b/src/jsonld/breadcrumb.tsx
@@ -9,10 +9,12 @@ export interface ItemListElements {
   position: number;
 }
 export interface BreadCrumbJsonLdProps {
+  id?: string;
   itemListElements: ItemListElements[];
 }
 
 const BreadCrumbJsonLd: FC<BreadCrumbJsonLdProps> = ({
+  id,
   itemListElements = [],
 }) => {
   const jslonld = `{
@@ -37,7 +39,7 @@ const BreadCrumbJsonLd: FC<BreadCrumbJsonLdProps> = ({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={markup(jslonld)}
-        key="jsonld-breadcrumb"
+        key={`jsonld-breadcrumb${id ? `-${id}` : ''}`}
       />
     </Head>
   );

--- a/src/jsonld/corporateContact.tsx
+++ b/src/jsonld/corporateContact.tsx
@@ -11,6 +11,7 @@ export interface ContactPoint {
   contactOption?: string | string[];
 }
 export interface CorporateContactJsonLdProps {
+  id?: string;
   url: string;
   contactPoint: ContactPoint[];
   logo?: string;
@@ -44,6 +45,7 @@ const buildContactPoint = (contactPoint: ContactPoint[]) =>
   );
 
 const CorporateContactJsonLd: FC<CorporateContactJsonLdProps> = ({
+  id,
   url,
   logo,
   contactPoint,
@@ -61,7 +63,7 @@ const CorporateContactJsonLd: FC<CorporateContactJsonLdProps> = ({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={markup(jslonld)}
-        key="jsonld-corporate-contact"
+        key={`jsonld-corporate-contact${id ? `-${id}` : ''}`}
       />
     </Head>
   );

--- a/src/jsonld/course.tsx
+++ b/src/jsonld/course.tsx
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import markup from '../utils/markup';
 
 export interface CourseJsonLdProps {
+  id?: string;
   courseName: string;
   description: string;
   providerName: string;
@@ -11,6 +12,7 @@ export interface CourseJsonLdProps {
 }
 
 const CourseJsonLd: FC<CourseJsonLdProps> = ({
+  id,
   courseName,
   description,
   providerName,
@@ -37,7 +39,7 @@ const CourseJsonLd: FC<CourseJsonLdProps> = ({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={markup(jslonld)}
-        key="jsonld-course"
+        key={`jsonld-course${id ? `-${id}` : ''}`}
       />
     </Head>
   );

--- a/src/jsonld/localBusiness.tsx
+++ b/src/jsonld/localBusiness.tsx
@@ -100,7 +100,7 @@ const LocalBusinessJsonLd: FC<LocalBusinessJsonLdProps> = ({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={markup(jslonld)}
-        key="jsonld-local-business"
+        key={`jsonld-local-business${id ? `-${id}` : ''}`}
       />
     </Head>
   );

--- a/src/jsonld/logo.tsx
+++ b/src/jsonld/logo.tsx
@@ -4,11 +4,12 @@ import Head from 'next/head';
 import markup from '../utils/markup';
 
 export interface LogoJsonLdProps {
+  id?: string;
   logo: string;
   url: string;
 }
 
-const LogoJsonLd: FC<LogoJsonLdProps> = ({ url, logo }) => {
+const LogoJsonLd: FC<LogoJsonLdProps> = ({ id, url, logo }) => {
   const jslonld = `{
     "@context": "http://schema.org",
     "@type": "Organization",
@@ -21,7 +22,7 @@ const LogoJsonLd: FC<LogoJsonLdProps> = ({ url, logo }) => {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={markup(jslonld)}
-        key="jsonld-logo"
+        key={`jsonld-logo${id ? `-${id}` : ''}`}
       />
     </Head>
   );

--- a/src/jsonld/newsarticle.tsx
+++ b/src/jsonld/newsarticle.tsx
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import markup from '../utils/markup';
 
 export interface NewsArticleJsonLdProps {
+  id?: string;
   url: string;
   title: string;
   images: ReadonlyArray<string>;
@@ -20,6 +21,7 @@ export interface NewsArticleJsonLdProps {
 }
 
 const NewsArticleJsonLd: FC<NewsArticleJsonLdProps> = ({
+  id,
   url,
   title,
   images = [],
@@ -71,7 +73,7 @@ const NewsArticleJsonLd: FC<NewsArticleJsonLdProps> = ({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={markup(jslonld)}
-        key="jsonld-newsarticle"
+        key={`jsonld-newsarticle${id ? `-${id}` : ''}`}
       />
     </Head>
   );

--- a/src/jsonld/product.tsx
+++ b/src/jsonld/product.tsx
@@ -36,6 +36,7 @@ type AggregateRating = {
 };
 
 export interface ProductJsonLdProps {
+  id?: string;
   productName: string;
   images?: string[];
   description?: string;
@@ -121,6 +122,7 @@ const buildOffers = (offers: Offers) => `
 `;
 
 const ProductJsonLd: FC<ProductJsonLdProps> = ({
+  id,
   productName,
   images = [],
   description,
@@ -156,7 +158,7 @@ const ProductJsonLd: FC<ProductJsonLdProps> = ({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={markup(jslonld)}
-        key="jsonld-product"
+        key={`jsonld-product${id ? `-${id}` : ''}`}
       />
     </Head>
   );

--- a/src/jsonld/socialProfile.tsx
+++ b/src/jsonld/socialProfile.tsx
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import markup from '../utils/markup';
 
 export interface SocialProfileJsonLdProps {
+  id?: string;
   type: string;
   name: string;
   url: string;
@@ -11,6 +12,7 @@ export interface SocialProfileJsonLdProps {
 }
 
 const SocialProfileJsonLd: FC<SocialProfileJsonLdProps> = ({
+  id,
   type,
   name,
   url,
@@ -31,7 +33,7 @@ const SocialProfileJsonLd: FC<SocialProfileJsonLdProps> = ({
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={markup(jslonld)}
-        key="jsonld-social"
+        key={`jsonld-social${id ? `-${id}` : ''}`}
       />
     </Head>
   );


### PR DESCRIPTION
Fixes: #136

## Description of Change(s):
Accepts optional key for JSON-LD elements, but still prefixes the key with the default values.

---

Some things to help get a PR reviewed and merged faster:

- Have you updated the documentation to go with your changes? YES
- Have you written or updated unit tests? NO EXISTING TESTS
- Have you written an integration test in the test app supplied? NO EXISTING TESTS
