### PR TITLE
Removed initial props from readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,15 +165,6 @@ import { DefaultSeo } from 'next-seo';
 import SEO from '../next-seo.config';
 
 export default class MyApp extends App {
-  static async getInitialProps({ Component, ctx }) {
-    let pageProps = {};
-    if (Component.getInitialProps) {
-      pageProps = await Component.getInitialProps(ctx);
-    }
-
-    return { pageProps };
-  }
-
   render() {
     const { Component, pageProps } = this.props;
     return (
@@ -1309,6 +1300,7 @@ Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. Contributions of any kind welcome!


### PR DESCRIPTION
Removed initial props from documentation.
This is currently giving warning from next since it turns off Automatic Static Optimization.

https://github.com/zeit/next.js/blob/master/errors/opt-out-auto-static-optimization.md