### PR TITLE
Moved props in redme for faqpage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1021,6 +1021,14 @@ export default () => (
 );
 ```
 
+**Required properties**
+
+| Property                        | Info                                                                          |
+| ------------------------------- | ----------------------------------------------------------------------------- |
+| `mainEntity`                    |                                                                               |
+| `mainEntity.questionName`       | The full text of the question. For example, "How long is the delivery time?". |
+| `mainENtity.acceptedAnswerText` | The full answer to the question.                                              |
+
 ### Job Posting
 
 ```jsx
@@ -1088,14 +1096,6 @@ export default () => (
 | `baseSalary.unitText`           | A string indicating the unit of measurement [Base salary guideline](https://developers.google.com/search/docs/data-types/job-posting#basesalary)    |
 | `employmentType`                | Type of employment [Employement type guideline](https://developers.google.com/search/docs/data-types/job-posting#basesalary)                        |  |
 | `jobLocationType`               | A description of the job location [Job Location type guideline](https://developers.google.com/search/docs/data-types/job-posting#job-location-type) |
-
-**Required properties**
-
-| Property                        | Info                                                                          |
-| ------------------------------- | ----------------------------------------------------------------------------- |
-| `mainEntity`                    |                                                                               |
-| `mainEntity.questionName`       | The full text of the question. For example, "How long is the delivery time?". |
-| `mainENtity.acceptedAnswerText` | The full answer to the question.                                              |
 
 ### Local Business
 


### PR DESCRIPTION
In this PR https://github.com/garmeeh/next-seo/pull/142 the documentation for JobPosting was added in the middle of faq page.
This will bring the faq page documentation together again.