### PR TITLE
Removed getInitialProps from e2e test app.

### DIFF
--- a/e2e/pages/_app.tsx
+++ b/e2e/pages/_app.tsx
@@ -5,15 +5,6 @@ import { DefaultSeo } from '../../lib';
 import SEO from '../next-seo.config';
 
 export default class MyApp extends App {
-  static async getInitialProps({ Component, ctx }: any) {
-    let pageProps = {};
-    if (Component.getInitialProps) {
-      pageProps = await Component.getInitialProps(ctx);
-    }
-
-    return { pageProps };
-  }
-
   render() {
     const { Component, pageProps } = this.props;
     return (


### PR DESCRIPTION
Removed get initial props from test app.
Since this is not the "standard" way of running a next app anymore.