### PR TITLE
add support for multiple offers in product jsonld

### DIFF
--- a/README.md
+++ b/README.md
@@ -1273,17 +1273,30 @@ export default () => (
         ratingValue: '4.4',
         reviewCount: '89',
       }}
-      offers={{
-        price: '119.99',
-        priceCurrency: 'USD',
-        priceValidUntil: '2020-11-05',
-        itemCondition: 'http://schema.org/UsedCondition',
-        availability: 'http://schema.org/InStock',
-        url: 'https://www.example.com/executive-anvil',
-        seller: {
-          name: 'Executive Objects',
+      offers={[
+        {
+          price: '119.99',
+          priceCurrency: 'USD',
+          priceValidUntil: '2020-11-05',
+          itemCondition: 'http://schema.org/UsedCondition',
+          availability: 'http://schema.org/InStock',
+          url: 'https://www.example.com/executive-anvil',
+          seller: {
+            name: 'Executive Objects',
+          },
         },
-      }}
+        {
+          price: '139.99',
+          priceCurrency: 'CAD',
+          priceValidUntil: '2020-09-05',
+          itemCondition: 'http://schema.org/UsedCondition',
+          availability: 'http://schema.org/InStock',
+          url: 'https://www.example.ca/executive-anvil',
+          seller: {
+            name: 'Executive Objects',
+          },
+        },
+      ]}
       mpn="925872"
     />
   </>

--- a/cypress/e2e/jsonld.spec.js
+++ b/cypress/e2e/jsonld.spec.js
@@ -352,19 +352,34 @@ describe('Validates JSON-LD For:', () => {
             ratingValue: '4.4',
             reviewCount: '89',
           },
-          offers: {
-            '@type': 'Offer',
-            priceCurrency: 'USD',
-            price: '119.99',
-            priceValidUntil: '2020-11-05',
-            itemCondition: 'http://schema.org/UsedCondition',
-            availability: 'http://schema.org/InStock',
-            url: 'https://www.example.com/executive-anvil',
-            seller: {
-              '@type': 'Organization',
-              name: 'Executive Objects',
+          offers: [
+            {
+              '@type': 'Offer',
+              price: '119.99',
+              priceCurrency: 'USD',
+              priceValidUntil: '2020-11-05',
+              itemCondition: 'http://schema.org/UsedCondition',
+              availability: 'http://schema.org/InStock',
+              url: 'https://www.example.com/executive-anvil',
+              seller: {
+                '@type': 'Organization',
+                name: 'Executive Objects',
+              },
             },
-          },
+            {
+              '@type': 'Offer',
+              price: '139.99',
+              priceCurrency: 'CAD',
+              priceValidUntil: '2020-09-05',
+              itemCondition: 'http://schema.org/UsedCondition',
+              availability: 'http://schema.org/InStock',
+              url: 'https://www.example.ca/executive-anvil',
+              seller: {
+                '@type': 'Organization',
+                name: 'Executive Objects',
+              },
+            },
+          ],
         });
       });
   });

--- a/cypress/schemas/common.js
+++ b/cypress/schemas/common.js
@@ -144,6 +144,71 @@ export const offers100 = {
   },
 };
 
+export const offers101 = {
+  version: {
+    major: 1,
+    minor: 0,
+    patch: 1,
+  },
+  schema: {
+    type: 'array',
+    description: 'Offers',
+    item: {
+      type: 'object',
+      properties: {
+        '@type': {
+          type: 'string',
+          description: 'Describes type',
+        },
+        priceCurrency: {
+          type: 'string',
+          description:
+            'Use standard formats: ISO 4217 currency format e.g. "USD"; Ticker symbol for cryptocurrencies e.g. "BTC"; well known names for Local Exchange Tradings Systems (LETS) and other currency types e.g. "Ithaca HOUR".',
+        },
+        price: {
+          type: 'string',
+          description: 'Price.',
+        },
+        priceValidUntil: {
+          type: 'string',
+          description: 'The date after which the price is no longer available.',
+        },
+        itemCondition: {
+          type: 'string',
+          description:
+            'itemCondition OfferItemCondition A predefined value from OfferItemCondition or a textual description of the condition of the product or service, or the products or services included in the offer.',
+        },
+        availability: {
+          type: 'string',
+          description:
+            'The availability of this item—for example In stock, Out of stock, Pre-order, etc.',
+        },
+        url: {
+          type: 'string',
+          description:
+            'A URL to the product web page (that includes the Offer).',
+        },
+        seller: {
+          ...seller100.schema,
+          see: seller100,
+        },
+      },
+    },
+    example: {
+      '@type': 'Offer',
+      priceCurrency: 'USD',
+      price: '119.99',
+      priceValidUntil: '2020-11-05',
+      itemCondition: 'http://schema.org/UsedCondition',
+      availability: 'http://schema.org/InStock',
+      seller: {
+        '@type': 'Organization',
+        name: 'Executive Objects',
+      },
+    },
+  },
+};
+
 export const rating100 = {
   version: {
     major: 1,

--- a/cypress/schemas/product-schema.js
+++ b/cypress/schemas/product-schema.js
@@ -1,5 +1,5 @@
 import { versionSchemas } from '@cypress/schema-tools';
-import { offers100, aggregateRating100, brand100, review100 } from './common';
+import { offers101, aggregateRating100, brand100, review100 } from './common';
 
 const product100 = {
   version: {
@@ -63,8 +63,8 @@ const product100 = {
         see: aggregateRating100,
       },
       offers: {
-        ...offers100.schema,
-        see: offers100,
+        ...offers101.schema,
+        see: offers101,
       },
     },
   },
@@ -112,18 +112,34 @@ const product100 = {
       ratingValue: '4.4',
       reviewCount: '89',
     },
-    offers: {
-      '@type': 'Offer',
-      priceCurrency: 'USD',
-      price: '119.99',
-      priceValidUntil: '2020-11-05',
-      itemCondition: 'http://schema.org/UsedCondition',
-      availability: 'http://schema.org/InStock',
-      seller: {
-        '@type': 'Organization',
-        name: 'Executive Objects',
+    offers: [
+      {
+        '@type': 'Offer',
+        price: '119.99',
+        priceCurrency: 'USD',
+        priceValidUntil: '2020-11-05',
+        itemCondition: 'http://schema.org/UsedCondition',
+        availability: 'http://schema.org/InStock',
+        url: 'https://www.example.com/executive-anvil',
+        seller: {
+          '@type': 'Organization',
+          name: 'Executive Objects',
+        },
       },
-    },
+      {
+        '@type': 'Offer',
+        price: '139.99',
+        priceCurrency: 'CAD',
+        priceValidUntil: '2020-09-05',
+        itemCondition: 'http://schema.org/UsedCondition',
+        availability: 'http://schema.org/InStock',
+        url: 'https://www.example.ca/executive-anvil',
+        seller: {
+          '@type': 'Organization',
+          name: 'Executive Objects',
+        },
+      },
+    ],
   },
 };
 

--- a/e2e/pages/jsonld.tsx
+++ b/e2e/pages/jsonld.tsx
@@ -148,7 +148,7 @@ export default () => (
         {
           author: {
             type: 'Person',
-            name: 'Jim'
+            name: 'Jim',
           },
           publisher: {
             type: 'Organization',
@@ -169,17 +169,30 @@ export default () => (
         ratingValue: '4.4',
         reviewCount: '89',
       }}
-      offers={{
-        price: '119.99',
-        priceCurrency: 'USD',
-        priceValidUntil: '2020-11-05',
-        itemCondition: 'http://schema.org/UsedCondition',
-        availability: 'http://schema.org/InStock',
-        url: 'https://www.example.com/executive-anvil',
-        seller: {
-          name: 'Executive Objects',
+      offers={[
+        {
+          price: '119.99',
+          priceCurrency: 'USD',
+          priceValidUntil: '2020-11-05',
+          itemCondition: 'http://schema.org/UsedCondition',
+          availability: 'http://schema.org/InStock',
+          url: 'https://www.example.com/executive-anvil',
+          seller: {
+            name: 'Executive Objects',
+          },
         },
-      }}
+        {
+          price: '139.99',
+          priceCurrency: 'CAD',
+          priceValidUntil: '2020-09-05',
+          itemCondition: 'http://schema.org/UsedCondition',
+          availability: 'http://schema.org/InStock',
+          url: 'https://www.example.ca/executive-anvil',
+          seller: {
+            name: 'Executive Objects',
+          },
+        },
+      ]}
       mpn="925872"
     />
 

--- a/src/jsonld/product.tsx
+++ b/src/jsonld/product.tsx
@@ -53,7 +53,7 @@ export interface ProductJsonLdProps {
   brand?: string;
   reviews?: Review[];
   aggregateRating?: AggregateRating;
-  offers: Offers;
+  offers: Offers | Offers[];
   sku?: string;
   gtin8?: string;
   gtin13?: string;
@@ -121,7 +121,7 @@ const buildAggregateRating = (aggregateRating: AggregateRating) => `
 // TODO: Docs for offers itemCondition & availability
 // TODO: Seller type, make dynamic
 const buildOffers = (offers: Offers) => `
-  "offers": {
+  {
     "@type": "Offer",
     "priceCurrency": "${offers.priceCurrency}",
     ${
@@ -143,7 +143,7 @@ const buildOffers = (offers: Offers) => `
         : ''
     }
     "price": "${offers.price}"
-  },
+  }
 `;
 
 const ProductJsonLd: FC<ProductJsonLdProps> = ({
@@ -173,7 +173,15 @@ const ProductJsonLd: FC<ProductJsonLdProps> = ({
     ${brand ? buildBrand(brand) : ''}
     ${reviews.length ? buildReviews(reviews) : ''}
     ${aggregateRating ? buildAggregateRating(aggregateRating) : ''}
-    ${offers ? buildOffers(offers) : ''}
+    ${
+      offers
+        ? `"offers": ${
+            Array.isArray(offers)
+              ? `[${offers.map(offer => `${buildOffers(offer)}`)}]`
+              : buildOffers(offers)
+          },`
+        : ''
+    }
     "name": "${productName}"
   }`;
 


### PR DESCRIPTION
## Description of Change(s):

closes #132 

Allows multiple offers to be provided as an array in product json LD (https://schema.org/Offer example 8 JSON-ld example shows that this should be supported). With this change there is still compatibility for providing the offer as a single object