### PR TITLE
Disable use `@babel/runtime-corejs2`

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,9 @@
 {
-  presets: ['next/babel', '@babel/typescript', 'minify'],
+  presets: [
+    ['next/babel', { 'transform-runtime': { corejs: false } }],
+    '@babel/typescript',
+    'minify',
+  ],
   plugins: ['@babel/plugin-transform-react-jsx'],
   ignore: ['node_modules'],
 }


### PR DESCRIPTION
## Description of Change(s):

Change `next/babel` options and don't use `@babel/runtime-corejs2`. This will allow you to build Next.js v9.2.3 without any problems.

Resolve #178