### PR TITLE
feat(minify-json-ld): minifies jsonLd output

### DIFF
--- a/src/jsonld/article.tsx
+++ b/src/jsonld/article.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import Head from 'next/head';
 
 import markup from '../utils/markup';
+import minifyJsonLd from '../utils/minifyJsonLd';
 
 export interface ArticleJsonLdProps {
   url: string;
@@ -58,7 +59,7 @@ const ArticleJsonLd: FC<ArticleJsonLdProps> = ({
     <Head>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={markup(jslonld)}
+        dangerouslySetInnerHTML={markup(minifyJsonLd(jslonld))}
         key="jsonld-article"
       />
     </Head>

--- a/src/jsonld/blog.tsx
+++ b/src/jsonld/blog.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import Head from 'next/head';
 
 import markup from '../utils/markup';
+import minifyJsonLd from '../utils/minifyJsonLd';
 
 export interface BlogJsonLdProps {
   url: string;
@@ -46,7 +47,7 @@ const BlogJsonLd: FC<BlogJsonLdProps> = ({
     <Head>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={markup(jslonld)}
+        dangerouslySetInnerHTML={markup(minifyJsonLd(jslonld))}
         key="jsonld-blog"
       />
     </Head>

--- a/src/jsonld/breadcrumb.tsx
+++ b/src/jsonld/breadcrumb.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import Head from 'next/head';
 
 import markup from '../utils/markup';
+import minifyJsonLd from '../utils/minifyJsonLd';
 
 export interface ItemListElements {
   item: string;
@@ -36,7 +37,7 @@ const BreadCrumbJsonLd: FC<BreadCrumbJsonLdProps> = ({
     <Head>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={markup(jslonld)}
+        dangerouslySetInnerHTML={markup(minifyJsonLd(jslonld))}
         key="jsonld-breadcrumb"
       />
     </Head>

--- a/src/jsonld/corporateContact.tsx
+++ b/src/jsonld/corporateContact.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import Head from 'next/head';
 
 import markup from '../utils/markup';
+import minifyJsonLd from '../utils/minifyJsonLd';
 
 export interface ContactPoint {
   contactType: string;
@@ -60,7 +61,7 @@ const CorporateContactJsonLd: FC<CorporateContactJsonLdProps> = ({
     <Head>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={markup(jslonld)}
+        dangerouslySetInnerHTML={markup(minifyJsonLd(jslonld))}
         key="jsonld-corporate-contact"
       />
     </Head>

--- a/src/jsonld/course.tsx
+++ b/src/jsonld/course.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import Head from 'next/head';
 
 import markup from '../utils/markup';
+import minifyJsonLd from '../utils/minifyJsonLd';
 
 export interface CourseJsonLdProps {
   courseName: string;
@@ -36,7 +37,7 @@ const CourseJsonLd: FC<CourseJsonLdProps> = ({
     <Head>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={markup(jslonld)}
+        dangerouslySetInnerHTML={markup(minifyJsonLd(jslonld))}
         key="jsonld-course"
       />
     </Head>

--- a/src/jsonld/dataset.tsx
+++ b/src/jsonld/dataset.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import Head from 'next/head';
 
 import markup from '../utils/markup';
+import minifyJsonLd from '../utils/minifyJsonLd';
 
 export interface DatasetJsonLdProps {
   description: string;
@@ -30,7 +31,7 @@ const DatasetJsonLd: FC<DatasetJsonLdProps> = ({
     <Head>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={markup(jslonld)}
+        dangerouslySetInnerHTML={markup(minifyJsonLd(jslonld))}
         key="jsonld-dataset"
       />
     </Head>

--- a/src/jsonld/event.tsx
+++ b/src/jsonld/event.tsx
@@ -3,8 +3,9 @@ import Head from 'next/head';
 
 import markup from '../utils/markup';
 import formatIfArray from '../utils/formatIfArray';
-import { Address } from '../types';
+import minifyJsonLd from '../utils/minifyJsonLd';
 import buildAddress from '../utils/buildAddress';
+import { Address } from '../types';
 
 type Location = {
   name: string;
@@ -56,7 +57,7 @@ const EventJsonLd: FC<EventJsonLdProps> = ({
     <Head>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={markup(jslonld)}
+        dangerouslySetInnerHTML={markup(minifyJsonLd(jslonld))}
         key="jsonld-event"
       />
     </Head>

--- a/src/jsonld/faqPage.tsx
+++ b/src/jsonld/faqPage.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Head from 'next/head';
 
 import markup from '../utils/markup';
+import minifyJsonLd from '../utils/minifyJsonLd';
 
 export interface Question {
   questionName: string;
@@ -35,7 +36,7 @@ const FAQPageJsonLd: React.FC<FAQPageJsonLdProps> = ({ mainEntity = [] }) => {
     <Head>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={markup(jslonld)}
+        dangerouslySetInnerHTML={markup(minifyJsonLd(jslonld))}
         key="jsonld-faq-page"
       />
     </Head>

--- a/src/jsonld/jobPosting.tsx
+++ b/src/jsonld/jobPosting.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import Head from 'next/head';
 
 import markup from '../utils/markup';
+import minifyJsonLd from '../utils/minifyJsonLd';
 
 export interface HiringOrganization {
   name: string;
@@ -83,7 +84,7 @@ const JobPostingJsonLd: FC<JobPostingJsonLdProps> = ({
       "name" : "${hiringOrganization.name}",
       "sameAs" : "${hiringOrganization.sameAs}"
     },
-    
+
     "jobLocation": {
       "@type": "Place",
       "address": {
@@ -112,7 +113,7 @@ const JobPostingJsonLd: FC<JobPostingJsonLdProps> = ({
     <Head>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={markup(jslonld)}
+        dangerouslySetInnerHTML={markup(minifyJsonLd(jslonld))}
         key="jsonld-jobPosting"
       />
     </Head>

--- a/src/jsonld/localBusiness.tsx
+++ b/src/jsonld/localBusiness.tsx
@@ -3,8 +3,9 @@ import Head from 'next/head';
 
 import markup from '../utils/markup';
 import formatIfArray from '../utils/formatIfArray';
-import { Address } from '../types';
+import minifyJsonLd from '../utils/minifyJsonLd';
 import buildAddress from '../utils/buildAddress';
+import { Address } from '../types';
 
 type Geo = {
   latitude: string;
@@ -119,7 +120,7 @@ const LocalBusinessJsonLd: FC<LocalBusinessJsonLdProps> = ({
     <Head>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={markup(jslonld)}
+        dangerouslySetInnerHTML={markup(minifyJsonLd(jslonld))}
         key="jsonld-local-business"
       />
     </Head>

--- a/src/jsonld/logo.tsx
+++ b/src/jsonld/logo.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import Head from 'next/head';
 
 import markup from '../utils/markup';
+import minifyJsonLd from '../utils/minifyJsonLd';
 
 export interface LogoJsonLdProps {
   logo: string;
@@ -20,7 +21,7 @@ const LogoJsonLd: FC<LogoJsonLdProps> = ({ url, logo }) => {
     <Head>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={markup(jslonld)}
+        dangerouslySetInnerHTML={markup(minifyJsonLd(jslonld))}
         key="jsonld-logo"
       />
     </Head>

--- a/src/jsonld/newsarticle.tsx
+++ b/src/jsonld/newsarticle.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import Head from 'next/head';
 
 import markup from '../utils/markup';
+import minifyJsonLd from '../utils/minifyJsonLd';
 
 export interface NewsArticleJsonLdProps {
   url: string;
@@ -46,7 +47,7 @@ const NewsArticleJsonLd: FC<NewsArticleJsonLdProps> = ({
       ${images.map(image => `"${image}"`)}
      ],
     "articleSection":"${section}",
-    "keywords": "${keywords}",    
+    "keywords": "${keywords}",
     "datePublished": "${datePublished}",
     "dateCreated": "${dateCreated || datePublished}",
     "dateModified": "${dateModified || datePublished}",
@@ -70,7 +71,7 @@ const NewsArticleJsonLd: FC<NewsArticleJsonLdProps> = ({
     <Head>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={markup(jslonld)}
+        dangerouslySetInnerHTML={markup(minifyJsonLd(jslonld))}
         key="jsonld-newsarticle"
       />
     </Head>

--- a/src/jsonld/product.tsx
+++ b/src/jsonld/product.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head';
 
 import markup from '../utils/markup';
 import formatIfArray from '../utils/formatIfArray';
+import minifyJsonLd from '../utils/minifyJsonLd';
 
 type ReviewRating = {
   bestRating?: string;
@@ -189,7 +190,7 @@ const ProductJsonLd: FC<ProductJsonLdProps> = ({
     <Head>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={markup(jslonld)}
+        dangerouslySetInnerHTML={markup(minifyJsonLd(jslonld))}
         key="jsonld-product"
       />
     </Head>

--- a/src/jsonld/recipe.tsx
+++ b/src/jsonld/recipe.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import Head from 'next/head';
 
 import markup from '../utils/markup';
+import minifyJsonLd from '../utils/minifyJsonLd';
 
 type AggregateRating = {
   ratingValue: string;
@@ -148,7 +149,7 @@ const RecipeJsonLd: FC<RecipeJsonLdProps> = ({
     <Head>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={markup(jslonld)}
+        dangerouslySetInnerHTML={markup(minifyJsonLd(jslonld))}
         key="jsonld-recipe"
       />
     </Head>

--- a/src/jsonld/socialProfile.tsx
+++ b/src/jsonld/socialProfile.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react';
 import Head from 'next/head';
 
 import markup from '../utils/markup';
+import minifyJsonLd from '../utils/minifyJsonLd';
 
 export interface SocialProfileJsonLdProps {
   type: string;
@@ -30,7 +31,7 @@ const SocialProfileJsonLd: FC<SocialProfileJsonLdProps> = ({
     <Head>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={markup(jslonld)}
+        dangerouslySetInnerHTML={markup(minifyJsonLd(jslonld))}
         key="jsonld-social"
       />
     </Head>

--- a/src/utils/minifyJsonLd.ts
+++ b/src/utils/minifyJsonLd.ts
@@ -1,0 +1,3 @@
+const minifyJsonLd = (jsonld: string) => JSON.stringify(JSON.parse(jsonld));
+
+export default minifyJsonLd;


### PR DESCRIPTION
## Description of Change(s):

Minifies the jsonLd content before rendering it on `<Head>`
I'm not entirely sure if this is the most efficient way of doing this, but definitely reliable and doesn't add any extra deps. I'd rather have the extra computational work than no compression at all. 

Closes https://github.com/garmeeh/next-seo/issues/263#issue-592275986

---

Some things to help get a PR reviewed and merged faster:

- Have you updated the documentation to go with your changes?
Not sure if it should be mentioned anywhere in the docs, up to suggestions. Would be no problem to do it
- Have you written or updated unit tests?
Didn't find any jsonLd related unit tests, and I didn't write any
- Have you written an integration test in the test app supplied?
Didn't write it but I tested on the test app and also ran cypress locally

