### PR TITLE
update outdated doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,10 +399,10 @@ mobileAlternate={{
 ```
 
 ```jsx
-languageAlternate={{
+languageAlternates={[{
   hrefLang: 'de-AT',
   href: 'https://www.canonical.ie/de',
-}}
+}]}
 ```
 
 #### Additional Meta Tags


### PR DESCRIPTION
It looks `languageAlternates` is right(not `languageAlternate`), am I correct?