### PR TITLE
Update Facebook appId to be a string in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ Some tools may report this an error. See [Issue #14](https://github.com/garmeeh/
 
 ```jsx
 facebook={{
-  appId: 1234567890,
+  appId: '1234567890',
 }}
 ```
 


### PR DESCRIPTION
## Description of Change(s):

Just a quick README update – was confused initially as your documentation shows `appId` as a number, but it requires a string.