### PR TITLE
[Feature] Q&A datatype support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ looking for inspiration on what to add.
   - [News Article](#news-article)
   - [Video](#video-1)
   - [Event](#event)
+  - [Q&A](#qa)
   - [Carousel](#carousel)
     - [Default (Summary List)](#default-summary-list)
     - [Course](#course-1)
@@ -1750,99 +1751,99 @@ export default Page;
 Q&A pages are web pages that contain data in a question and answer format, which is one question followed by its answers.
 
 ```jsx
-import { QAPageJsonld } from 'next-seo'
+import { QAPageJsonld } from 'next-seo';
 
 const Page = () => (
   <>
     <h1>Q&A Page JSON-LD</h1>
-      <QAPageJsonld
-          mainEntity={{
-          name: 'How many ounces are there in a pound?',
-          text:
-            'I have taken up a new interest in baking and keep running across directions in ounces and pounds. I have to translate between them and was wondering how many ounces are in a pound?',
-          answerCount: 3,
-          upvotedCount: 26,
-          dateCreated: '2016-07-23T21:11Z',
-          author: { 
-              name: 'New Baking User' 
+    <QAPageJsonld
+      mainEntity={{
+        name: 'How many ounces are there in a pound?',
+        text:
+          'I have taken up a new interest in baking and keep running across directions in ounces and pounds. I have to translate between them and was wondering how many ounces are in a pound?',
+        answerCount: 3,
+        upvotedCount: 26,
+        dateCreated: '2016-07-23T21:11Z',
+        author: {
+          name: 'New Baking User',
+        },
+        acceptedAnswer: {
+          text: '1 pound (lb) is equal to 16 ounces (oz).',
+          dateCreated: '2016-11-02T21:11Z',
+          upvotedCount: 1337,
+          url: 'https://example.com/question1#acceptedAnswer',
+          author: {
+            name: 'SomeUser',
           },
-          acceptedAnswer: {
-            text: '1 pound (lb) is equal to 16 ounces (oz).',
+        },
+        suggestedAnswer: [
+          {
+            text:
+              'Are you looking for ounces or fluid ounces? If you are looking for fluid ounces there are 15.34 fluid ounces in a pound of water.',
             dateCreated: '2016-11-02T21:11Z',
-            upvotedCount: 1337,
-            url: 'https://example.com/question1#acceptedAnswer',
+            upvotedCount: 42,
+            url: 'https://example.com/question1#suggestedAnswer1',
             author: {
-              name: 'SomeUser',
+              name: 'AnotherUser',
             },
           },
-          suggestedAnswer: [
-            {
-              text:
-                'Are you looking for ounces or fluid ounces? If you are looking for fluid ounces there are 15.34 fluid ounces in a pound of water.',
-              dateCreated: '2016-11-02T21:11Z',
-              upvotedCount: 42,
-              url: 'https://example.com/question1#suggestedAnswer1',
-              author: {
-                name: 'AnotherUser',
-              },
+          {
+            text: `I can't remember exactly, but I think 18 ounces in a lb. You might want to double check that.`,
+            dateCreated: '2016-11-06T21:11Z',
+            upvotedCount: 0,
+            url: 'https://example.com/question1#suggestedAnswer2',
+            author: {
+              name: 'ConfusedUser',
             },
-            {
-              text: `I can't remember exactly, but I think 18 ounces in a lb. You might want to double check that.`,
-              dateCreated: '2016-11-06T21:11Z',
-              upvotedCount: 0,
-              url: 'https://example.com/question1#suggestedAnswer2',
-              author: {
-                name: 'ConfusedUser',
-              },
-            },
-          ],
-        }}
-      />
-    </>
+          },
+        ],
+      }}
+    />
+  </>
 );
 
 export default Page;
 ```
+
 **Required properties**
 
-| Property                             | Info                                                                                                                          |
-| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| `mainEntity`                         | The Question for this page must be nested under the mainEntity property of the QAPageJsonld component.                        |
+| Property     | Info                                                                                                   |
+| ------------ | ------------------------------------------------------------------------------------------------------ |
+| `mainEntity` | The Question for this page must be nested under the mainEntity property of the QAPageJsonld component. |
 
 **`mainEntity` Required properties**
 
-| Property                             | Info                                                                                                                          |
-| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| `answerCount`                        | The total number of answers to the question.                                                                                  |
-| `acceptedAnswer` or `suggestedAnswer`| To be eligible for the rich result, a question must have at least one answer – either an acceptedAnswer or a suggestedAnswer. |
-| `name`                               | The full text of the short form of the question.                                                                              |
+| Property                              | Info                                                                                                                          |
+| ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `answerCount`                         | The total number of answers to the question.                                                                                  |
+| `acceptedAnswer` or `suggestedAnswer` | To be eligible for the rich result, a question must have at least one answer – either an acceptedAnswer or a suggestedAnswer. |
+| `name`                                | The full text of the short form of the question.                                                                              |
 
 **`mainEntity` Supported properties**
 
-| Property          | Info                                                                        |
-| ----------------- | --------------------------------------------------------------------------- |
-| `author`          | The author of the question.                                                 |
-| `dateCreated`     | The date at which the question was added to the page, in ISO-8601 format.   |
-| `text`            | The full text of the long form of the question.                             |
-| `upvoteCount`     | The total number of votes that this question has received.                  |
+| Property      | Info                                                                      |
+| ------------- | ------------------------------------------------------------------------- |
+| `author`      | The author of the question.                                               |
+| `dateCreated` | The date at which the question was added to the page, in ISO-8601 format. |
+| `text`        | The full text of the long form of the question.                           |
+| `upvoteCount` | The total number of votes that this question has received.                |
 
 **`acceptedAnswer`/`suggestedAnswer` Required properties**
 
-| Property  | Info                         |
-| --------- | ---------------------------- |
-| `text`    | The full text of the answer. |
+| Property | Info                         |
+| -------- | ---------------------------- |
+| `text`   | The full text of the answer. |
 
 **`acceptedAnswer`/`suggestedAnswer` Supported properties**
 
-| Property          | Info                                                                        |
-| ----------------- | --------------------------------------------------------------------------- |
-| `author`          | The author of the question.                                                 |
-| `dateCreated`     | The date at which the question was added to the page, in ISO-8601 format.   |
-| `upvoteCount`     | The total number of votes that this question has received.                  |
-| `url`             | A URL that links directly to this answer.                                   |
+| Property      | Info                                                                      |
+| ------------- | ------------------------------------------------------------------------- |
+| `author`      | The author of the question.                                               |
+| `dateCreated` | The date at which the question was added to the page, in ISO-8601 format. |
+| `upvoteCount` | The total number of votes that this question has received.                |
+| `url`         | A URL that links directly to this answer.                                 |
 
 For reference and more info check [Google's Search Q&A DataType](https://developers.google.com/search/docs/data-types/qapage)
-
 
 ### Carousel
 

--- a/cypress/e2e/jsonld.spec.js
+++ b/cypress/e2e/jsonld.spec.js
@@ -1,7 +1,7 @@
 import { assertSchema } from '@cypress/schema-tools';
 import schemas from '../schemas';
 
-const expectedJSONResults = 16;
+const expectedJSONResults = 17;
 
 const articleLdJsonIndex = 0;
 const breadcrumbLdJsonIndex = 1;
@@ -19,6 +19,7 @@ const jobPostingLdJsonIndex = 12;
 const eventLdJsonIndex = 13;
 const datasetLdJsonIndex = 14;
 const recipeLdJsonIndex = 15;
+const qaPageLdJsonIndex = 16;
 
 describe('Validates JSON-LD For:', () => {
   it('Article', () => {
@@ -788,6 +789,79 @@ describe('Validates JSON-LD For:', () => {
         };
 
         expect(jsonLD).to.deep.equal(expectedObject);
+      });
+  });
+
+  it('Q&A Page', () => {
+    cy.visit('http://localhost:3000/jsonld');
+    cy.get('head script[type="application/ld+json"]')
+      .should('have.length', expectedJSONResults)
+      .then(tags => {
+        const jsonLD = JSON.parse(tags[qaPageLdJsonIndex].innerHTML);
+        assertSchema(schemas)('Q&A Page', '1.0.0')(jsonLD);
+      });
+  });
+
+  it('Q&A Page Matches', () => {
+    cy.visit('http://localhost:3000/jsonld');
+    cy.get('head script[type="application/ld+json"]')
+      .should('have.length', expectedJSONResults)
+      .then(tags => {
+        const jsonLD = JSON.parse(tags[qaPageLdJsonIndex].innerHTML);
+        expect(jsonLD).to.deep.equal({
+          '@context': 'https://schema.org',
+          '@type': 'QAPage',
+          mainEntity: {
+            '@type': 'Question',
+            name: 'How many ounces are there in a pound?',
+            text:
+              'I have taken up a new interest in baking and keep running across directions in ounces and pounds. I have to translate between them and was wondering how many ounces are in a pound?',
+            answerCount: 3,
+            upvoteCount: 26,
+            dateCreated: '2016-07-23T21:11Z',
+            author: {
+              '@type': 'Person',
+              name: 'New Baking User',
+            },
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: '1 pound (lb) is equal to 16 ounces (oz).',
+              dateCreated: '2016-11-02T21:11Z',
+              upvoteCount: 1337,
+              url: 'https://example.com/question1#acceptedAnswer',
+              author: {
+                '@type': 'Person',
+                name: 'SomeUser',
+              },
+            },
+            suggestedAnswer: [
+              {
+                '@type': 'Answer',
+                text:
+                  'Are you looking for ounces or fluid ounces? If you are looking for fluid ounces there are 15.34 fluid ounces in a pound of water.',
+                dateCreated: '2016-11-02T21:11Z',
+                upvoteCount: 42,
+                url: 'https://example.com/question1#suggestedAnswer1',
+                author: {
+                  '@type': 'Person',
+                  name: 'AnotherUser',
+                },
+              },
+              {
+                '@type': 'Answer',
+                text:
+                  "I can't remember exactly, but I think 18 ounces in a lb. You might want to double check that.",
+                dateCreated: '2016-11-06T21:11Z',
+                upvoteCount: 0,
+                url: 'https://example.com/question1#suggestedAnswer2',
+                author: {
+                  '@type': 'Person',
+                  name: 'ConfusedUser',
+                },
+              },
+            ],
+          },
+        });
       });
   });
 

--- a/cypress/schemas/index.js
+++ b/cypress/schemas/index.js
@@ -15,6 +15,7 @@ import jobPostingVersions from './job-posting-schema';
 import eventVersion from './event-schema';
 import datasetVersion from './dataset-schema';
 import recipeVersion from './recipe-schema';
+import qaPageVersions from './qa-page-schema';
 
 const schemas = combineSchemas(
   articleVersions,
@@ -32,5 +33,6 @@ const schemas = combineSchemas(
   eventVersion,
   datasetVersion,
   recipeVersion,
+  qaPageVersions,
 );
 export default schemas;

--- a/cypress/schemas/qa-page-schema.js
+++ b/cypress/schemas/qa-page-schema.js
@@ -1,0 +1,183 @@
+import { versionSchemas } from '@cypress/schema-tools';
+import { author100 } from './common';
+
+const qaPage100 = {
+  version: {
+    major: 1,
+    minor: 0,
+    patch: 0,
+  },
+  schema: {
+    type: 'object',
+    title: 'Q&A Page',
+    description: 'An example schema describing JSON-LD for type: Q&A Page',
+    properties: {
+      '@context': {
+        type: 'string',
+        description: 'Schema.org context',
+      },
+      '@type': {
+        type: 'string',
+        description: 'QAPage',
+      },
+      mainEntity: {
+        type: 'object',
+        properties: {
+          '@type': {
+            type: 'string',
+            description: 'Question',
+          },
+          name: {
+            type: 'string',
+            description: 'The full text of the short form of the question.',
+          },
+          text: {
+            type: 'string',
+            description: 'The full text of the long form of the question.',
+          },
+          answerCount: {
+            type: 'number',
+            description: 'The total number of answers to the question.',
+          },
+          upvoteCount: {
+            type: 'number',
+            description:
+              'The total number of votes that this question has received.',
+          },
+          dateCreated: {
+            type: 'string',
+            description:
+              'The date at which the question was added to the page, in ISO-8601 format.',
+          },
+          author: {
+            ...author100.schema,
+            see: author100,
+          },
+          acceptedAnswer: {
+            type: 'object',
+            properties: {
+              '@type': {
+                type: 'string',
+                description: 'Answer',
+              },
+              text: {
+                type: 'string',
+                description: 'The full text of the answer.',
+              },
+              dateCreated: {
+                type: 'string',
+                description:
+                  'The date at which the answer was added to the page, in ISO-8601 format.',
+              },
+              upvoteCount: {
+                type: 'number',
+                description:
+                  'The total number of votes that this answer has received.',
+              },
+              url: {
+                type: 'string',
+                description: 'A URL that links directly to this answer.',
+              },
+              author: {
+                ...author100.schema,
+                see: author100,
+              },
+            },
+          },
+          suggestedAnswer: {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                '@type': {
+                  type: 'string',
+                  description: 'Answer',
+                },
+                text: {
+                  type: 'string',
+                  description: 'The full text of the answer.',
+                },
+                dateCreated: {
+                  type: 'string',
+                  description:
+                    'The date at which the answer was added to the page, in ISO-8601 format.',
+                },
+                upvoteCount: {
+                  type: 'number',
+                  description:
+                    'The total number of votes that this answer has received.',
+                },
+                url: {
+                  type: 'string',
+                  description: 'A URL that links directly to this answer.',
+                },
+                author: {
+                  ...author100.schema,
+                  see: author100,
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    required: true,
+  },
+  example: {
+    '@context': 'https://schema.org',
+    '@type': 'QAPage',
+    mainEntity: {
+      '@type': 'Question',
+      name: 'How many ounces are there in a pound?',
+      text:
+        'I have taken up a new interest in baking and keep running across directions in ounces and pounds. I have to translate between them and was wondering how many ounces are in a pound?',
+      answerCount: 3,
+      upvoteCount: 26,
+      dateCreated: '2016-07-23T21:11Z',
+      author: {
+        '@type': 'Person',
+        name: 'New Baking User',
+      },
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: '1 pound (lb) is equal to 16 ounces (oz).',
+        dateCreated: '2016-11-02T21:11Z',
+        upvoteCount: 1337,
+        url: 'https://example.com/question1#acceptedAnswer',
+        author: {
+          '@type': 'Person',
+          name: 'SomeUser',
+        },
+      },
+      suggestedAnswer: [
+        {
+          '@type': 'Answer',
+          text:
+            'Are you looking for ounces or fluid ounces? If you are looking for fluid ounces there are 15.34 fluid ounces in a pound of water.',
+          dateCreated: '2016-11-02T21:11Z',
+          upvoteCount: 42,
+          url: 'https://example.com/question1#suggestedAnswer1',
+          author: {
+            '@type': 'Person',
+            name: 'AnotherUser',
+          },
+        },
+        {
+          '@type': 'Answer',
+          text:
+            " I can't remember exactly, but I think 18 ounces in a lb. You might want to double check that.",
+          dateCreated: '2016-11-06T21:11Z',
+          upvoteCount: 0,
+          url: 'https://example.com/question1#suggestedAnswer2',
+          author: {
+            '@type': 'Person',
+            name: 'ConfusedUser',
+          },
+        },
+      ],
+    },
+  },
+};
+
+const qaPageVersions = versionSchemas(qaPage100);
+export default qaPageVersions;

--- a/e2e/pages/jsonld.tsx
+++ b/e2e/pages/jsonld.tsx
@@ -15,6 +15,7 @@ import {
   EventJsonLd,
   DatasetJsonLd,
   RecipeJsonLd,
+  QAPageJsonld,
 } from '../..';
 import Links from '../components/links';
 
@@ -387,6 +388,48 @@ export default () => (
         ],
         expires: '2019-02-05T08:00:00+08:00',
         watchCount: 2347,
+      }}
+    />
+
+    <QAPageJsonld
+      mainEntity={{
+        name: 'How many ounces are there in a pound?',
+        text:
+          'I have taken up a new interest in baking and keep running across directions in ounces and pounds. I have to translate between them and was wondering how many ounces are in a pound?',
+        answerCount: 3,
+        upvotedCount: 26,
+        dateCreated: '2016-07-23T21:11Z',
+        author: { name: 'New Baking User' },
+        acceptedAnswer: {
+          text: '1 pound (lb) is equal to 16 ounces (oz).',
+          dateCreated: '2016-11-02T21:11Z',
+          upvotedCount: 1337,
+          url: 'https://example.com/question1#acceptedAnswer',
+          author: {
+            name: 'SomeUser',
+          },
+        },
+        suggestedAnswer: [
+          {
+            text:
+              'Are you looking for ounces or fluid ounces? If you are looking for fluid ounces there are 15.34 fluid ounces in a pound of water.',
+            dateCreated: '2016-11-02T21:11Z',
+            upvotedCount: 42,
+            url: 'https://example.com/question1#suggestedAnswer1',
+            author: {
+              name: 'AnotherUser',
+            },
+          },
+          {
+            text: `I can't remember exactly, but I think 18 ounces in a lb. You might want to double check that.`,
+            dateCreated: '2016-11-06T21:11Z',
+            upvotedCount: 0,
+            url: 'https://example.com/question1#suggestedAnswer2',
+            author: {
+              name: 'ConfusedUser',
+            },
+          },
+        ],
       }}
     />
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -33,6 +33,7 @@ export {
 } from './jsonld/newsarticle';
 export { default as EventJsonLd, EventJsonLdProps } from './jsonld/event';
 export { default as VideoJsonLd, VideoJsonLdProps } from './jsonld/video';
+export { default as QAPageJsonld, QAPageJsonldProps } from './jsonld/qaPage';
 export { default as RecipeJsonLd, RecipeJsonLdProps } from './jsonld/recipe';
 export {
   default as CarouselJsonLd,

--- a/src/jsonld/qaPage.tsx
+++ b/src/jsonld/qaPage.tsx
@@ -92,7 +92,7 @@ const buildQuestions = (mainEntity: Question) => `{
             ${
               suggested.upvotedCount
                 ? `"upvoteCount": ${suggested.upvotedCount},`
-                : ''
+                : `"upvoteCount": ${0},`
             }
             ${suggested.url ? `"url": "${suggested.url}",` : ''}
               ${
@@ -119,7 +119,7 @@ const QAPageJsonLd: React.FC<QAPageJsonldProps> = ({ mainEntity }) => {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={markup(jslonld)}
-        key="jsonld-faq-page"
+        key="jsonld-qa-page"
       />
     </Head>
   );

--- a/src/jsonld/qaPage.tsx
+++ b/src/jsonld/qaPage.tsx
@@ -16,7 +16,6 @@ export interface Answer {
 }
 
 export interface Question {
-  keyOverride?: string;
   name: string;
   answerCount: number;
   acceptedAnswer?: Answer;
@@ -29,6 +28,7 @@ export interface Question {
 
 export interface QAPageJsonldProps {
   mainEntity: Question;
+  keyOverride?: string;
 }
 
 const buildQuestions = (mainEntity: Question) => `{
@@ -117,7 +117,10 @@ const buildQuestions = (mainEntity: Question) => `{
         }
 }`;
 
-const QAPageJsonLd: React.FC<QAPageJsonldProps> = ({ mainEntity }) => {
+const QAPageJsonLd: React.FC<QAPageJsonldProps> = ({
+  mainEntity,
+  keyOverride,
+}) => {
   const jslonld = `{
     "@context": "https://schema.org",
     "@type": "QAPage",
@@ -128,9 +131,7 @@ const QAPageJsonLd: React.FC<QAPageJsonldProps> = ({ mainEntity }) => {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={markup(jslonld)}
-        key={`jsonld-qa${
-          mainEntity.keyOverride ? `-${mainEntity.keyOverride}` : ''
-        }`}
+        key={`jsonld-qa${keyOverride ? `-${keyOverride}` : ''}`}
       />
     </Head>
   );

--- a/src/jsonld/qaPage.tsx
+++ b/src/jsonld/qaPage.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import Head from 'next/head';
+
+import markup from '../utils/markup';
+
+export interface Person {
+  name: string;
+}
+
+export interface Answer {
+  text: string;
+  dateCreated?: Date;
+  upvotedCount?: number;
+  url?: string;
+  author?: Person;
+}
+
+export interface Question {
+  name: string;
+  answerCount: number;
+  acceptedAnswer: Answer;
+  suggestedAnswer: Answer[];
+  text?: string;
+  author?: Person;
+  upvotedCount?: number;
+  dateCreated?: Date;
+}
+
+export interface QAPageJsonldProps {
+  mainEntity: Question;
+}

--- a/src/jsonld/qaPage.tsx
+++ b/src/jsonld/qaPage.tsx
@@ -9,7 +9,7 @@ export interface Person {
 
 export interface Answer {
   text: string;
-  dateCreated?: Date;
+  dateCreated?: string;
   upvotedCount?: number;
   url?: string;
   author?: Person;
@@ -23,9 +23,106 @@ export interface Question {
   text?: string;
   author?: Person;
   upvotedCount?: number;
-  dateCreated?: Date;
+  dateCreated?: string;
 }
 
 export interface QAPageJsonldProps {
   mainEntity: Question;
 }
+
+const buildQuestions = (mainEntity: Question) => `{
+        "@type": "Question",
+        "name": ${mainEntity.name},
+        ${mainEntity.text ? `"text": ${mainEntity.text}` : ''},
+        "answerCount": ${mainEntity.answerCount},
+        ${
+          mainEntity.upvotedCount
+            ? `"upvoteCount": ${mainEntity.upvotedCount}`
+            : ''
+        },
+        ${
+          mainEntity.dateCreated
+            ? `"dateCreated": ${mainEntity.dateCreated}`
+            : ''
+        },
+        ${
+          mainEntity.author
+            ? `"author": {
+          "@type": "Person",
+          "name": ${mainEntity.author.name}
+        }`
+            : ''
+        },
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": ${mainEntity.acceptedAnswer.text},
+          ${
+            mainEntity.acceptedAnswer.dateCreated
+              ? `"dateCreated": ${mainEntity.acceptedAnswer.dateCreated}`
+              : ''
+          },
+          ${
+            mainEntity.acceptedAnswer.upvotedCount
+              ? `"upvoteCount": ${mainEntity.acceptedAnswer.upvotedCount}`
+              : ''
+          },
+          ${
+            mainEntity.acceptedAnswer.url
+              ? `"url": ${mainEntity.acceptedAnswer.url}`
+              : ''
+          },
+          ${
+            mainEntity.acceptedAnswer.author
+              ? `"author": {
+            "@type": "Person",
+            "name": ${mainEntity.acceptedAnswer.author.name}
+          }`
+              : ''
+          }
+        },
+        "suggestedAnswer": [${mainEntity.suggestedAnswer.map(
+          suggested => `{
+            "@type": "Answer",
+            "text": ${suggested.text},
+            ${
+              suggested.dateCreated
+                ? `"dateCreated": ${suggested.dateCreated}`
+                : ''
+            },
+            ${
+              suggested.upvotedCount
+                ? `"upvoteCount": ${suggested.upvotedCount}`
+                : ''
+            },
+            ${suggested.url ? `"url": ${suggested.url}` : ''},
+              ${
+                suggested.author
+                  ? `"author": {
+                        "@type": "Person",
+                        "name": ${suggested.author.name}
+                    }`
+                  : ''
+              }
+        },`,
+        )}
+    ]
+}`;
+
+const QAPageJsonLd: React.FC<QAPageJsonldProps> = ({ mainEntity }) => {
+  const jslonld = `{
+    "@context": "https://schema.org",
+    "@type": "QAPage",
+    "mainEntity": ${buildQuestions(mainEntity)}
+    }`;
+  return (
+    <Head>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={markup(jslonld)}
+        key="jsonld-faq-page"
+      />
+    </Head>
+  );
+};
+
+export default QAPageJsonLd;

--- a/src/jsonld/qaPage.tsx
+++ b/src/jsonld/qaPage.tsx
@@ -50,15 +50,15 @@ const buildQuestions = (mainEntity: Question) => `{
             ? `"author": {
           "@type": "Person",
           "name": "${mainEntity.author.name}"
-        }`
+        },`
             : ''
-        },
+        }
         "acceptedAnswer": {
           "@type": "Answer",
           "text": "${mainEntity.acceptedAnswer.text}",
           ${
             mainEntity.acceptedAnswer.dateCreated
-              ? `"dateCreated": "${mainEntity.acceptedAnswer.dateCreated},"`
+              ? `"dateCreated": "${mainEntity.acceptedAnswer.dateCreated}",`
               : ''
           }
           ${
@@ -68,7 +68,7 @@ const buildQuestions = (mainEntity: Question) => `{
           }
           ${
             mainEntity.acceptedAnswer.url
-              ? `"url": "${mainEntity.acceptedAnswer.url},"`
+              ? `"url": "${mainEntity.acceptedAnswer.url}",`
               : ''
           }
           ${

--- a/src/jsonld/qaPage.tsx
+++ b/src/jsonld/qaPage.tsx
@@ -16,10 +16,11 @@ export interface Answer {
 }
 
 export interface Question {
+  keyOverride?: string;
   name: string;
   answerCount: number;
-  acceptedAnswer: Answer;
-  suggestedAnswer: Answer[];
+  acceptedAnswer?: Answer;
+  suggestedAnswer?: Answer[];
   text?: string;
   author?: Person;
   upvotedCount?: number;
@@ -53,7 +54,9 @@ const buildQuestions = (mainEntity: Question) => `{
         },`
             : ''
         }
-        "acceptedAnswer": {
+        ${
+          mainEntity.acceptedAnswer
+            ? `"acceptedAnswer": {
           "@type": "Answer",
           "text": "${mainEntity.acceptedAnswer.text}",
           ${
@@ -79,9 +82,13 @@ const buildQuestions = (mainEntity: Question) => `{
           }`
               : ''
           }
-        },
-        "suggestedAnswer": [${mainEntity.suggestedAnswer.map(
-          suggested => `{
+        },`
+            : ''
+        }
+        ${
+          mainEntity.suggestedAnswer
+            ? `"suggestedAnswer": [${mainEntity.suggestedAnswer.map(
+                suggested => `{
             "@type": "Answer",
             "text": "${suggested.text}",
             ${
@@ -104,8 +111,10 @@ const buildQuestions = (mainEntity: Question) => `{
                   : ''
               }
         }`,
-        )}
-    ]
+              )}
+    ]`
+            : ''
+        }
 }`;
 
 const QAPageJsonLd: React.FC<QAPageJsonldProps> = ({ mainEntity }) => {
@@ -119,7 +128,9 @@ const QAPageJsonLd: React.FC<QAPageJsonldProps> = ({ mainEntity }) => {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={markup(jslonld)}
-        key="jsonld-qa-page"
+        key={`jsonld-qa${
+          mainEntity.keyOverride ? `-${mainEntity.keyOverride}` : ''
+        }`}
       />
     </Head>
   );

--- a/src/jsonld/qaPage.tsx
+++ b/src/jsonld/qaPage.tsx
@@ -32,50 +32,50 @@ export interface QAPageJsonldProps {
 
 const buildQuestions = (mainEntity: Question) => `{
         "@type": "Question",
-        "name": ${mainEntity.name},
-        ${mainEntity.text ? `"text": ${mainEntity.text}` : ''},
+        "name": "${mainEntity.name}",
+        ${mainEntity.text ? `"text": "${mainEntity.text}",` : ''}
         "answerCount": ${mainEntity.answerCount},
         ${
           mainEntity.upvotedCount
-            ? `"upvoteCount": ${mainEntity.upvotedCount}`
+            ? `"upvoteCount": ${mainEntity.upvotedCount},`
             : ''
-        },
+        }
         ${
           mainEntity.dateCreated
-            ? `"dateCreated": ${mainEntity.dateCreated}`
+            ? `"dateCreated": "${mainEntity.dateCreated}",`
             : ''
-        },
+        }
         ${
           mainEntity.author
             ? `"author": {
           "@type": "Person",
-          "name": ${mainEntity.author.name}
+          "name": "${mainEntity.author.name}"
         }`
             : ''
         },
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": ${mainEntity.acceptedAnswer.text},
+          "text": "${mainEntity.acceptedAnswer.text}",
           ${
             mainEntity.acceptedAnswer.dateCreated
-              ? `"dateCreated": ${mainEntity.acceptedAnswer.dateCreated}`
+              ? `"dateCreated": "${mainEntity.acceptedAnswer.dateCreated},"`
               : ''
-          },
+          }
           ${
             mainEntity.acceptedAnswer.upvotedCount
-              ? `"upvoteCount": ${mainEntity.acceptedAnswer.upvotedCount}`
+              ? `"upvoteCount": ${mainEntity.acceptedAnswer.upvotedCount},`
               : ''
-          },
+          }
           ${
             mainEntity.acceptedAnswer.url
-              ? `"url": ${mainEntity.acceptedAnswer.url}`
+              ? `"url": "${mainEntity.acceptedAnswer.url},"`
               : ''
-          },
+          }
           ${
             mainEntity.acceptedAnswer.author
               ? `"author": {
             "@type": "Person",
-            "name": ${mainEntity.acceptedAnswer.author.name}
+            "name": "${mainEntity.acceptedAnswer.author.name}"
           }`
               : ''
           }
@@ -83,27 +83,27 @@ const buildQuestions = (mainEntity: Question) => `{
         "suggestedAnswer": [${mainEntity.suggestedAnswer.map(
           suggested => `{
             "@type": "Answer",
-            "text": ${suggested.text},
+            "text": "${suggested.text}",
             ${
               suggested.dateCreated
-                ? `"dateCreated": ${suggested.dateCreated}`
+                ? `"dateCreated": "${suggested.dateCreated}",`
                 : ''
-            },
+            }
             ${
               suggested.upvotedCount
-                ? `"upvoteCount": ${suggested.upvotedCount}`
+                ? `"upvoteCount": ${suggested.upvotedCount},`
                 : ''
-            },
-            ${suggested.url ? `"url": ${suggested.url}` : ''},
+            }
+            ${suggested.url ? `"url": "${suggested.url}",` : ''}
               ${
                 suggested.author
                   ? `"author": {
                         "@type": "Person",
-                        "name": ${suggested.author.name}
+                        "name": "${suggested.author.name}"
                     }`
                   : ''
               }
-        },`,
+        }`,
         )}
     ]
 }`;


### PR DESCRIPTION
## Description of Change(s):

The addition of the [Q&A DataType](https://developers.google.com/search/docs/data-types/qapage) to handle questions and answers with the JSON-LD scripts.

![Reference image](https://developers.google.com/search/docs/data-types/images/qa-example-screenshot.png)

Progress:

- [x] Type definitions.
- [x] Structured JSON data.
- [x] Export definitions and props.
- [x] Added example use case.
- [x] Code and test with Cypress.
- [x] Documentation.

---

Some things to help get a PR reviewed and merged faster:

- Have you updated the documentation to go with your changes? **Yes, added all the documentation for all Q&A props** 
- Have you written or updated unit tests? **No**
- Have you written an integration test in the test app supplied? **Yes, I've written e2e tests for the Q&A Page JSON-LD**
