### PR TITLE
Support a defaultTitle config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ looking for inspiration on what to add.
   - [Default SEO Configuration](#default-seo-configuration)
   - [NextSeo Options](#nextseo-options)
     - [Title Template](#title-template)
+    - [Default Title](#default-title)
     - [No Index](#no-index)
     - [dangerouslySetAllPagesToNoIndex](#dangerouslysetallpagestonoindex)
     - [No Follow](#no-follow)

--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ From now on all of your pages will have the defaults above applied.
 | ---------------------------------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | `titleTemplate`                    | string                  | Allows you to set default title template that will be added to your title [More Info](#title-template)                                                                               |
 | `title`                            | string                  | Set the meta title of the page                                                                                                                                                       |
+| `defaultTitle`                     | string                  | If no title is set on a page, this string will be used instead of an empty `titleTemplate` [More Info](#default-title)                                                               |
 | `noindex`                          | boolean (default false) | Sets whether page should be indexed or not [More Info](#no-index)                                                                                                                    |
 | `nofollow`                         | boolean (default false) | Sets whether page should be followed or not [More Info](#no-follow)                                                                                                                  |
 | `description`                      | string                  | Set the page meta description                                                                                                                                                        |
@@ -295,6 +296,15 @@ titleTemplate = 'Next SEO | %s';
 title = 'This is my title';
 titleTemplate = '%s | Next SEO';
 // outputs: This is my title | Next SEO
+```
+
+#### Default Title
+
+```js
+title = undefined;
+titleTemplate = 'Next SEO | %s';
+defaultTitle = 'Next SEO';
+// outputs: Next SEO
 ```
 
 #### No Index

--- a/src/meta/__tests__/buildTags.spec.tsx
+++ b/src/meta/__tests__/buildTags.spec.tsx
@@ -292,6 +292,22 @@ it('displays title with titleTemplate integrated', () => {
   expect(title.innerHTML).toMatch(`${template} | ${SEO.title}`);
 });
 
+it('displays defaultTitle when no title is provided', () => {
+  const defaultTitle = 'Next SEO';
+  const overrideProps = {
+    titleTemplate: `${defaultTitle} | %s`,
+    defaultTitle,
+  };
+  const tags = buildTags(overrideProps);
+  const { container } = render(<>{React.Children.toArray(tags)}</>);
+  const title = getByText(
+    container,
+    (content, element) =>
+      element.tagName.toLowerCase() === 'title' && content.startsWith(defaultTitle),
+  );
+  expect(title.innerHTML).toMatch(defaultTitle);
+});
+
 const ArticleSEO = {
   title: 'Article Page Title',
   description: 'Description of article page',

--- a/src/meta/__tests__/buildTags.spec.tsx
+++ b/src/meta/__tests__/buildTags.spec.tsx
@@ -294,11 +294,11 @@ it('displays title with titleTemplate integrated', () => {
 
 it('displays defaultTitle when no title is provided', () => {
   const defaultTitle = 'Next SEO';
-  const overrideProps = {
+  const props = {
     titleTemplate: `${defaultTitle} | %s`,
     defaultTitle,
   };
-  const tags = buildTags(overrideProps);
+  const tags = buildTags(props);
   const { container } = render(<>{React.Children.toArray(tags)}</>);
   const title = getByText(
     container,

--- a/src/meta/buildTags.tsx
+++ b/src/meta/buildTags.tsx
@@ -24,6 +24,11 @@ const buildTags = (config: BuildTagsParams) => {
     if (defaults.templateTitle) {
       updatedTitle = defaults.templateTitle.replace(/%s/g, () => updatedTitle);
     }
+  } else if (config.defaultTitle) {
+    updatedTitle = config.defaultTitle;
+  }
+  
+  if (updatedTitle) {
     tagsToRender.push(<title key="title">{updatedTitle}</title>);
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,6 +139,7 @@ export type MetaTag = HTML5MetaTag | RDFaMetaTag;
 export interface NextSeoProps {
   title?: string;
   titleTemplate?: string;
+  defaultTitle?: string;
   noindex?: boolean;
   nofollow?: boolean;
   description?: string;


### PR DESCRIPTION
This change causes a `<title>` tag to be rendered if no `config.title` is provided but a `config.defaultTitle` is. It skips the templating step and renders the `defaultTitle` as is.

Fixes #366 
