### PR TITLE
Readme: Version numbers unclear #611

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ export default Page;
 
 **Note**
 
-Multiple images is only available in version `7.0.0-canary.0`+
+Multiple images is available from next.js version `7.0.0-canary.0`
 
 For versions `6.0.0` - `7.0.0-canary.0` you just need to supply a single item array:
 
@@ -601,7 +601,7 @@ export default Page;
 
 **Note**
 
-Multiple images is only available in version `7.0.0-canary.0`+
+Multiple images is available from next.js version `7.0.0-canary.0`
 
 For versions `6.0.0` - `7.0.0-canary.0` you just need to supply a single item array:
 
@@ -661,7 +661,7 @@ export default Page;
 
 **Note**
 
-Multiple images, authors, tags is only available in version `7.0.0-canary.0`+
+Multiple images, authors, tags is available from next.js version `7.0.0-canary.0`
 
 For versions `6.0.0` - `7.0.0-canary.0` you just need to supply a single item array:
 
@@ -735,7 +735,7 @@ export default Page;
 
 **Note**
 
-Multiple images, authors, tags is only available in version `7.0.0-canary.0`+
+Multiple images, authors, tags is available from next.js version `7.0.0-canary.0`
 
 For versions `6.0.0` - `7.0.0-canary.0` you just need to supply a single item array:
 
@@ -806,7 +806,7 @@ export default Page;
 
 **Note**
 
-Multiple images is only available in version `7.0.0-canary.0`+
+Multiple images is available from next.js version `7.0.0-canary.0`
 
 For versions `6.0.0` - `7.0.0-canary.0` you just need to supply a single item array:
 


### PR DESCRIPTION
Readme: Version numbers 6.0.0 - 7.0.0-canary.0 unclear #611



## Description of Change(s):

Changed _is only available in version `7.0.0-canary.0`+_ to _is available from next.js version `7.0.0-canary.0`_ in 5 places.

Some things to help get a PR reviewed and merged faster:

- Have you updated the documentation to go with your changes? **Documentation only change**
- Have you written or updated unit tests? **No functional change**
- Have you written an integration test in the test app supplied? **No functional change**

The above are generally required on all PR's.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
