### PR TITLE
Fixed reference to next-seo.config.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ import App, { Container } from 'next/app';
 import { DefaultSeo } from 'next-seo';
 
 // import your default seo configuration
-import SEO from '../next-seo.config';
+import SEO from '../next-seo.config.js';
 
 export default class MyApp extends App {
   render() {


### PR DESCRIPTION
Untested on Mac/Linux, but at least on Windows, the ".js" is required.

## Description of Change(s):
- Fixed reference to next-seo.config.js
- See commit note
---

Some things to help get a PR reviewed and merged faster:

- Have you updated the documentation to go with your changes?
This is the README
