### PR TITLE
Add additionalLinkTags

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ looking for inspiration on what to add.
     - [Canonical URL](#canonical-url)
     - [Alternate](#alternate)
     - [Additional Meta Tags](#additional-meta-tags)
+    - [Additional Link Tags](#additional-link-tags)
 - [Open Graph](#open-graph)
   - [Open Graph Examples](#open-graph-examples)
     - [Basic](#basic)
@@ -259,6 +260,7 @@ From now on all of your pages will have the defaults above applied.
 | `mobileAlternate.href`             | string                  | Set the mobile page alternate url                                                                                                                                                    |
 | `languageAlternates`               | array                   | Set the language of the alternate urls. Expects array of objects with the shape: `{ hrefLang: string, href: string }`                                                                |
 | `additionalMetaTags`               | array                   | Allows you to add a meta tag that is not documented here. [More Info](#additional-meta-tags)                                                                                         |
+| `additionalLinkTags`               | array                   | Allows you to add a link tag that is not documented here. [More Info](#additional-link-tags)                                                                                         |
 | `twitter.cardType`                 | string                  | The card type, which will be one of `summary`, `summary_large_image`, `app`, or `player`                                                                                             |
 | `twitter.site`                     | string                  | @username for the website used in the card footer                                                                                                                                    |
 | `twitter.handle`                   | string                  | @username for the content creator / author (outputs as `twitter:creator`)                                                                                                            |
@@ -540,6 +542,44 @@ it will result in this being rendered:
 
 ```html
 <meta property="dc:creator" content="Jane Doe" />,
+```
+
+#### Additional Link Tags
+
+This allows you to add any other link tags that are not covered in the `config`.
+
+`rel` and `href` is required.
+
+Example:
+
+```js
+additionalLinkTags={[
+  {
+    rel: 'icon',
+    href: 'https://www.test.ie/favicon.ico',
+  },
+  {
+    rel: 'apple-touch-icon',
+    href: 'https://www.test.ie/touch-icon-ipad.jpg',
+    sizes: '76x76'
+  },
+  {
+    rel: 'manifest',
+    href: '/manifest.json'
+  }
+]}
+```
+
+it will result in this being rendered:
+
+```html
+<link rel="icon" href="https://www.test.ie/favicon.ico" />
+<link
+  rel="apple-touch-icon"
+  href="https://www.test.ie/touch-icon-ipad.jpg"
+  sizes="76x76"
+/>
+<link rel="manifest" href="/manifest.json" />
 ```
 
 ## Open Graph

--- a/cypress/e2e/seo.spec.js
+++ b/cypress/e2e/seo.spec.js
@@ -108,8 +108,6 @@ describe('SEO Meta', () => {
     cy.get('head link[rel="apple-touch-icon"]')
       .should('have.length', 2)
       .then(tags => {
-        console.log('tags 0', tags[0].sizes);
-        console.log('tags 1', tags[1].sizes);
         expect(tags[0].sizes[0]).to.equal('76x76');
         expect(tags[1].sizes[0]).to.equal('120x120');
       });
@@ -278,6 +276,13 @@ describe('SEO Meta', () => {
       'content',
       'IE=edge; chrome=1',
     );
+    cy.get('head link[rel="apple-touch-icon"]')
+      .should('have.length', 3)
+      .then(tags => {
+        expect(tags[0].sizes[0]).to.equal('76x76');
+        expect(tags[1].sizes[0]).to.equal('120x120');
+        expect(tags[2].sizes[0]).to.equal('180x180');
+      });
   });
 
   it('Profile SEO loads correctly', () => {

--- a/cypress/e2e/seo.spec.js
+++ b/cypress/e2e/seo.spec.js
@@ -100,6 +100,27 @@ describe('SEO Meta', () => {
       'content',
       'summary_large_image',
     );
+    cy.get('head link[rel="icon"]').should(
+      'have.attr',
+      'href',
+      'https://www.test.ie/favicon.ico',
+    );
+    cy.get('head link[rel="apple-touch-icon"]')
+      .should('have.length', 2)
+      .then(tags => {
+        console.log('tags 0', tags[0].sizes);
+        console.log('tags 1', tags[1].sizes);
+        expect(tags[0].sizes[0]).to.equal('76x76');
+        expect(tags[1].sizes[0]).to.equal('120x120');
+      });
+    cy.get('head link[rel="mask-icon"]')
+      .should('have.attr', 'href', 'https://www.test.ie/safari-pinned-tab.svg')
+      .should('have.attr', 'color', '#193860');
+    cy.get('head link[rel="manifest"]').should(
+      'have.attr',
+      'href',
+      '/manifest.json',
+    );
   });
 
   it('SEO Robots props applied correctly', () => {

--- a/e2e/next-seo.config.ts
+++ b/e2e/next-seo.config.ts
@@ -17,6 +17,31 @@ const APP_DEFAULT_SEO: DefaultSeoProps = {
       href: 'https://www.canonical.ie/de',
     },
   ],
+  additionalLinkTags: [
+    {
+      rel: 'icon',
+      href: 'https://www.test.ie/favicon.ico',
+    },
+    {
+      rel: 'apple-touch-icon',
+      href: 'https://www.test.ie/touch-icon-ipad.jpg',
+      sizes: '76x76',
+    },
+    {
+      rel: 'apple-touch-icon',
+      href: 'https://www.test.ie/touch-icon-iphone-retina.jpg',
+      sizes: '120x120',
+    },
+    {
+      rel: 'mask-icon',
+      href: 'https://www.test.ie/safari-pinned-tab.svg',
+      color: '#193860',
+    },
+    {
+      rel: 'manifest',
+      href: '/manifest.json',
+    },
+  ],
   openGraph: {
     type: 'website',
     locale: 'en_IE',

--- a/e2e/pages/overridden.tsx
+++ b/e2e/pages/overridden.tsx
@@ -81,6 +81,13 @@ const Overridden = () => (
           content: 'IE=edge; chrome=1',
         },
       ]}
+      additionalLinkTags={[
+        {
+          rel: 'apple-touch-icon',
+          href: 'https://www.test.ie/touch-icon-iphone.jpg',
+          sizes: '180x180',
+        },
+      ]}
     />
     <h1>Overridden Seo</h1>
     <Links />

--- a/src/meta/__tests__/__snapshots__/buildTags.spec.tsx.snap
+++ b/src/meta/__tests__/__snapshots__/buildTags.spec.tsx.snap
@@ -584,5 +584,28 @@ exports[`renders correctly 1`] = `
     href="https://www.canonical.ie"
     rel="canonical"
   />
+  <link
+    href="https://www.test.ie/favicon.ico"
+    rel="icon"
+  />
+  <link
+    href="https://www.test.ie/touch-icon-ipad.jpg"
+    rel="apple-touch-icon"
+    sizes="76x76"
+  />
+  <link
+    href="https://www.test.ie/touch-icon-iphone-retina.jpg"
+    rel="apple-touch-icon"
+    sizes="120x120"
+  />
+  <link
+    color="#193860"
+    href="https://www.test.ie/safari-pinned-tab.svg"
+    rel="mask-icon"
+  />
+  <link
+    href="/manifest.json"
+    rel="manifest"
+  />
 </div>
 `;

--- a/src/meta/__tests__/buildTags.spec.tsx
+++ b/src/meta/__tests__/buildTags.spec.tsx
@@ -26,6 +26,31 @@ const SEO: BuildTagsParams = {
       href: 'https://www.canonical.ie/sk',
     },
   ],
+  additionalLinkTags: [
+    {
+      rel: 'icon',
+      href: 'https://www.test.ie/favicon.ico',
+    },
+    {
+      rel: 'apple-touch-icon',
+      href: 'https://www.test.ie/touch-icon-ipad.jpg',
+      sizes: '76x76',
+    },
+    {
+      rel: 'apple-touch-icon',
+      href: 'https://www.test.ie/touch-icon-iphone-retina.jpg',
+      sizes: '120x120',
+    },
+    {
+      rel: 'mask-icon',
+      href: 'https://www.test.ie/safari-pinned-tab.svg',
+      color: '#193860',
+    },
+    {
+      rel: 'manifest',
+      href: '/manifest.json',
+    },
+  ],
   openGraph: {
     type: 'website',
     locale: 'en_IE',
@@ -303,7 +328,8 @@ it('displays defaultTitle when no title is provided', () => {
   const title = getByText(
     container,
     (content, element) =>
-      element.tagName.toLowerCase() === 'title' && content.startsWith(defaultTitle),
+      element.tagName.toLowerCase() === 'title' &&
+      content.startsWith(defaultTitle),
   );
   expect(title.innerHTML).toMatch(defaultTitle);
 });

--- a/src/meta/buildTags.tsx
+++ b/src/meta/buildTags.tsx
@@ -663,8 +663,10 @@ const buildTags = (config: BuildTagsParams) => {
   }
 
   if (config.additionalLinkTags?.length) {
-    config.additionalLinkTags.forEach((tag, index) => {
-      tagsToRender.push(<link key={`link${index}`} {...tag} />);
+    config.additionalLinkTags.forEach(tag => {
+      tagsToRender.push(
+        <link key={`link${tag.keyOverride ?? tag.href}${tag.rel}`} {...tag} />,
+      );
     });
   }
 

--- a/src/meta/buildTags.tsx
+++ b/src/meta/buildTags.tsx
@@ -662,6 +662,12 @@ const buildTags = (config: BuildTagsParams) => {
     });
   }
 
+  if (config.additionalLinkTags?.length) {
+    config.additionalLinkTags.forEach((tag, index) => {
+      tagsToRender.push(<link key={`link${index}`} {...tag} />);
+    });
+  }
+
   return tagsToRender;
 };
 

--- a/src/meta/defaultSEO.tsx
+++ b/src/meta/defaultSEO.tsx
@@ -24,6 +24,7 @@ export default class extends Component<DefaultSeoProps, {}> {
       defaultOpenGraphVideoHeight,
       mobileAlternate,
       languageAlternates,
+      additionalLinkTags,
     } = this.props;
 
     return (
@@ -46,6 +47,7 @@ export default class extends Component<DefaultSeoProps, {}> {
           defaultOpenGraphVideoHeight,
           mobileAlternate,
           languageAlternates,
+          additionalLinkTags,
         })}
       </Head>
     );

--- a/src/meta/nextSEO.tsx
+++ b/src/meta/nextSEO.tsx
@@ -19,6 +19,7 @@ export default class extends Component<NextSeoProps, {}> {
       titleTemplate,
       mobileAlternate,
       languageAlternates,
+      additionalLinkTags,
     } = this.props;
 
     return (
@@ -37,6 +38,7 @@ export default class extends Component<NextSeoProps, {}> {
           titleTemplate,
           mobileAlternate,
           languageAlternates,
+          additionalLinkTags,
         })}
       </Head>
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,6 +145,7 @@ interface LinkTag {
   sizes?: string;
   type?: string;
   color?: string;
+  keyOverride?: string;
 }
 
 export interface BaseMetaTag {

--- a/src/types.ts
+++ b/src/types.ts
@@ -139,6 +139,14 @@ interface LanguageAlternate {
   href: string;
 }
 
+interface LinkTag {
+  rel: string;
+  href: string;
+  sizes?: string;
+  type?: string;
+  color?: string;
+}
+
 export interface BaseMetaTag {
   content: string;
   keyOverride?: string;
@@ -197,6 +205,7 @@ export interface NextSeoProps {
   facebook?: { appId: string };
   twitter?: Twitter;
   additionalMetaTags?: ReadonlyArray<MetaTag>;
+  additionalLinkTags?: ReadonlyArray<LinkTag>;
 }
 
 export interface DefaultSeoProps extends NextSeoProps {


### PR DESCRIPTION
## Description of Change(s):
Closes: https://github.com/garmeeh/next-seo/issues/182
This PR adds `additionalLinkTags` to config.
Since link tags are used for icons, manifest, and so on which are really important for SEO, this should be included in config.

---

Some things to help get a PR reviewed and merged faster:

- Have you updated the documentation to go with your changes? :white_check_mark:
- Have you written or updated unit tests? :white_check_mark:
- Have you written an integration test in the test app supplied? :white_check_mark:

The above are generally required on all PR's.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
