### PR TITLE
Add itemprop="image" to the first og:image meta tag.

### DIFF
--- a/src/meta/__tests__/__snapshots__/buildTags.spec.tsx.snap
+++ b/src/meta/__tests__/__snapshots__/buildTags.spec.tsx.snap
@@ -79,6 +79,7 @@ exports[`Article SEO renders correctly 1`] = `
   />
   <meta
     content="https://www.test.ie/og-image-article-title-01.jpg"
+    itemprop="image"
     property="og:image"
   />
   <meta
@@ -187,6 +188,7 @@ exports[`Book SEO renders correctly 1`] = `
   />
   <meta
     content="https://www.test.ie/og-image-book-title-01.jpg"
+    itemprop="image"
     property="og:image"
   />
   <meta
@@ -287,6 +289,7 @@ exports[`Profile SEO renders correctly 1`] = `
   />
   <meta
     content="https://www.test.ie/og-image-firstlast123-01.jpg"
+    itemprop="image"
     property="og:image"
   />
   <meta
@@ -419,6 +422,7 @@ exports[`Video SEO renders correctly 1`] = `
   />
   <meta
     content="https://www.test.ie/og-image-video-title-01.jpg"
+    itemprop="image"
     property="og:image"
   />
   <meta
@@ -522,6 +526,7 @@ exports[`renders correctly 1`] = `
   />
   <meta
     content="https://www.test.ie/image-01.jpg"
+    itemprop="image"
     property="og:image"
   />
   <meta

--- a/src/meta/__tests__/buildTags.spec.tsx
+++ b/src/meta/__tests__/buildTags.spec.tsx
@@ -141,9 +141,9 @@ it('returns full array for default seo object', () => {
     'meta[property="og:description"]',
   );
   const ogImage00 = container.querySelectorAll(
-    `meta[content="${SEO.openGraph.images[0].url}"]`,
+    `meta[content="${SEO.openGraph.images[0].url}"][itemprop="image"]`,
   );
-  const ogImageTag00 = tags.filter(item => item.key === 'og:image:01');
+  const ogImageTag00 = tags.filter(item => item.key === 'og:image:00');
   const ogImage01 = container.querySelectorAll(
     `meta[content="${SEO.openGraph.images[1].url}"]`,
   );

--- a/src/meta/buildTags.tsx
+++ b/src/meta/buildTags.tsx
@@ -504,6 +504,7 @@ const buildTags = (config: BuildTagsParams) => {
             key={`og:image:0${index}`}
             property="og:image"
             content={image.url}
+            {...(index === 0 && { itemProp: 'image' })}
           />,
         );
 


### PR DESCRIPTION
Hi,

I wanted to propose a little change on the OG image data. I noticed that What'sApp does not show the image which is defined in `og:image` in its preview box. The internet suggests that this can be fixed by adding `itemprop="image"` to the `<meta />` tag which holds the image url for OpenGraph. When I added it to all `og:image` tags React would only keep the last one added. I guess itemprop: image is only allowed once. 

So my question: Do you want to support this not-really-spec-conforming behavior from What'sApp?

I updated the snapshots and the unit test (also fixed a typo there). Documentation is not added yet, I wanted to ask first.