### PR TITLE
Don't add robots meta tags if not configured

### DIFF
--- a/cypress/e2e/seo.spec.js
+++ b/cypress/e2e/seo.spec.js
@@ -18,16 +18,6 @@ describe('SEO Meta', () => {
       'href',
       'https://www.canonical.ie/a',
     );
-    cy.get('head meta[name="robots"]').should(
-      'have.attr',
-      'content',
-      'index,follow',
-    );
-    cy.get('head meta[name="googlebot"]').should(
-      'have.attr',
-      'content',
-      'index,follow',
-    );
     cy.get('head meta[property="og:type"]').should(
       'have.attr',
       'content',

--- a/src/meta/buildTags.tsx
+++ b/src/meta/buildTags.tsx
@@ -90,7 +90,7 @@ const buildTags = (config: BuildTagsParams) => {
         }${robotsParams}`}
       />,
     );
-  } else {
+  } else if (robotsParams) {
     tagsToRender.push(
       <meta
         key="robots"


### PR DESCRIPTION
## Description of Change(s):

This make sure that robots meta tags are not unnecessarily added when no configuration is passed to them. This makes the page payload slightly smaller.

As [mentioned by Google](https://developers.google.com/search/docs/advanced/crawling/special-tags):
> The default values are index, follow and don't need to be specified.

And by [Moz](https://moz.com/blog/the-ultimate-guide-to-seo-meta-tags): 
> One huge misconception is that you have to have a robots meta tag. Let's make this clear: In terms of indexing and link following, if you don't specify a meta robots tag, they read that as index,follow. It's only if you want to change one of those two commands that you need to add meta robots. 