### PR TITLE
Extend props for ProductJsonLd component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1670,6 +1670,16 @@ const Page = () => (
       ]}
       description="Sleeker than ACME's Classic Anvil, the Executive Anvil is perfect for the business traveler looking for something to drop from a height."
       brand="ACME"
+      color="blue"
+      manufacturerName="Gary Meehan"
+      manufacturerLogo="https://www.example.com/photos/logo.jpg"
+      material="steel"
+      slogan="For the business traveller looking for something to drop from a height."
+      disambiguatingDescription="Executive Anvil, perfect for the business traveller."
+      releaseDate="2014-02-05T08:00:00+08:00"
+      productionDate="2015-02-05T08:00:00+08:00"
+      purchaseDate="2015-02-06T08:00:00+08:00"
+      award="Best Executive Anvil Award."
       reviews={[
         {
           author: {

--- a/cypress/e2e/jsonld.spec.js
+++ b/cypress/e2e/jsonld.spec.js
@@ -422,6 +422,24 @@ describe('Validates JSON-LD For:', () => {
             '@type': 'Thing',
             name: 'ACME',
           },
+          color: 'blue',
+          manufacturer: {
+            '@type': 'Organization',
+            name: 'Gary Meehan',
+            logo: {
+              '@type': 'ImageObject',
+              url: 'https://www.example.com/photos/logo.jpg',
+            },
+          },
+          material: 'steel',
+          slogan:
+            'For the business traveller looking for something to drop from a height.',
+          disambiguatingDescription:
+            'Executive Anvil, perfect for the business traveller.',
+          releaseDate: '2014-02-05T08:00:00+08:00',
+          productionDate: '2015-02-05T08:00:00+08:00',
+          purchaseDate: '2015-02-06T08:00:00+08:00',
+          award: 'Best Executive Anvil Award.',
           review: [
             {
               '@type': 'Review',

--- a/e2e/pages/jsonld.tsx
+++ b/e2e/pages/jsonld.tsx
@@ -233,6 +233,16 @@ const JsonLD = () => (
       ]}
       description="Sleeker than ACME's Classic Anvil, the Executive Anvil is perfect for the business traveler looking for something to drop from a height."
       brand="ACME"
+      color="blue"
+      manufacturerName="Gary Meehan"
+      manufacturerLogo="https://www.example.com/photos/logo.jpg"
+      material="steel"
+      slogan="For the business traveller looking for something to drop from a height."
+      disambiguatingDescription="Executive Anvil, perfect for the business traveller."
+      releaseDate="2014-02-05T08:00:00+08:00"
+      productionDate="2015-02-05T08:00:00+08:00"
+      purchaseDate="2015-02-06T08:00:00+08:00"
+      award="Best Executive Anvil Award."
       reviews={[
         {
           author: {
@@ -599,7 +609,7 @@ const JsonLD = () => (
       operatingSystem="ANDROID"
       applicationCategory="GameApplication"
     />
-        
+
     <CollectionPageJsonLd
       name="Resistance 3: Fall of Man"
       hasPart={[

--- a/src/jsonld/product.tsx
+++ b/src/jsonld/product.tsx
@@ -52,6 +52,16 @@ export interface ProductJsonLdProps {
   gtin13?: string;
   gtin14?: string;
   mpn?: string;
+  color?: string;
+  manufacturerName?: string;
+  manufacturerLogo?: string;
+  material?: string | ProductJsonLdProps;
+  slogan?: string;
+  disambiguatingDescription?: string;
+  productionDate?: string;
+  purchaseDate?: string;
+  releaseDate?: string;
+  award?: string;
 }
 
 const buildBrand = (brand: string) => `
@@ -126,6 +136,16 @@ const ProductJsonLd: FC<ProductJsonLdProps> = ({
   aggregateRating,
   offers,
   aggregateOffer,
+  color,
+  manufacturerName,
+  manufacturerLogo,
+  material,
+  slogan,
+  disambiguatingDescription,
+  productionDate,
+  releaseDate,
+  purchaseDate,
+  award,
 }) => {
   const jslonld = `{
     "@context": "https://schema.org/",
@@ -140,6 +160,26 @@ const ProductJsonLd: FC<ProductJsonLdProps> = ({
     ${brand ? buildBrand(brand) : ''}
     ${reviews.length ? buildReviews(reviews) : ''}
     ${aggregateRating ? buildAggregateRating(aggregateRating) : ''}
+    ${color ? `"color": "${color}",` : ''}
+    ${material ? `"material": "${material}",` : ''}
+    ${slogan ? `"slogan": "${slogan}",` : ''}
+    ${
+      disambiguatingDescription
+        ? `"disambiguatingDescription": "${disambiguatingDescription}",`
+        : ''
+    }
+    ${productionDate ? `"productionDate": "${productionDate}",` : ''}
+    ${releaseDate ? `"releaseDate": "${releaseDate}",` : ''}
+    ${purchaseDate ? `"purchaseDate": "${purchaseDate}",` : ''}
+    ${award ? `"award": "${award}",` : ''}
+    "manufacturer": {
+      "@type": "Organization",
+      "name": "${manufacturerName}",
+      "logo": {
+        "@type": "ImageObject",
+        "url": "${manufacturerLogo}"
+      }
+    },
     ${
       offers
         ? `"offers": ${


### PR DESCRIPTION
Adds support for a few currently missing options in ProductJsonLd

## Description of Change(s):
Following the spec https://schema.org/Product

Adds:

* color
* manufacturerName
* manufacturerLogo
* material
* slogan
* disambiguatingDescription
* releaseDate
* productionDate
* purchaseDate
* award

Other: 
- Updated Product in README to reflect changes
- Updated  tests to reflect changes