### PR TITLE
fix: missing aggregate rating fields

### DIFF
--- a/cypress/e2e/jsonld.spec.js
+++ b/cypress/e2e/jsonld.spec.js
@@ -447,8 +447,10 @@ describe('Validates JSON-LD For:', () => {
           ],
           aggregateRating: {
             '@type': 'AggregateRating',
-            ratingValue: '4.4',
+            ratingValue: '44',
             reviewCount: '89',
+            ratingCount: '684',
+            bestRating: '100',
           },
           offers: [
             {

--- a/cypress/schemas/common.js
+++ b/cypress/schemas/common.js
@@ -50,6 +50,10 @@ export const aggregateRating100 = {
         type: 'string',
         description: 'The count of total number of reviews.',
       },
+      bestRating: {
+        type: 'string',
+        description: 'Highest rating',
+      },
     },
     example: {
       '@type': 'AggregateRating',

--- a/e2e/pages/jsonld.tsx
+++ b/e2e/pages/jsonld.tsx
@@ -255,8 +255,10 @@ const JsonLD = () => (
         },
       ]}
       aggregateRating={{
-        ratingValue: '4.4',
+        ratingValue: '44',
         reviewCount: '89',
+        ratingCount: '684',
+        bestRating: '100',
       }}
       offers={[
         {
@@ -599,7 +601,7 @@ const JsonLD = () => (
       operatingSystem="ANDROID"
       applicationCategory="GameApplication"
     />
-        
+
     <CollectionPageJsonLd
       name="Resistance 3: Fall of Man"
       hasPart={[

--- a/src/jsonld/product.tsx
+++ b/src/jsonld/product.tsx
@@ -34,7 +34,9 @@ export type Review = {
 
 export type AggregateRating = {
   ratingValue: string;
-  reviewCount: string;
+  reviewCount?: string;
+  ratingCount?: string;
+  bestRating?: string;
 };
 
 export interface ProductJsonLdProps {
@@ -106,8 +108,22 @@ export const buildReviews = (reviews: Review[]) => `
 export const buildAggregateRating = (aggregateRating: AggregateRating) => `
   "aggregateRating": {
       "@type": "AggregateRating",
-      "ratingValue": "${aggregateRating.ratingValue}",
-      "reviewCount": "${aggregateRating.reviewCount}"
+      ${
+        aggregateRating.ratingCount
+          ? `"ratingCount": "${aggregateRating.ratingCount}",`
+          : ''
+      }
+      ${
+        aggregateRating.reviewCount
+          ? `"reviewCount": "${aggregateRating.reviewCount}",`
+          : ''
+      }
+      ${
+        aggregateRating.bestRating
+          ? `"bestRating": "${aggregateRating.bestRating}",`
+          : ''
+      }
+      "ratingValue": "${aggregateRating.ratingValue}"
     },
 `;
 

--- a/src/jsonld/recipe.tsx
+++ b/src/jsonld/recipe.tsx
@@ -9,14 +9,30 @@ import { Video } from '../types';
 
 export type AggregateRating = {
   ratingValue: string;
-  ratingCount: string;
+  reviewCount?: string;
+  ratingCount?: string;
+  bestRating?: string;
 };
 
 export const buildAggregateRating = (aggregateRating: AggregateRating) => `
   "aggregateRating": {
       "@type": "AggregateRating",
-      "ratingValue": "${aggregateRating.ratingValue}",
-      "ratingCount": "${aggregateRating.ratingCount}"
+      ${
+        aggregateRating.ratingCount
+          ? `"ratingCount": "${aggregateRating.ratingCount}",`
+          : ''
+      }
+      ${
+        aggregateRating.reviewCount
+          ? `"reviewCount": "${aggregateRating.reviewCount}",`
+          : ''
+      }
+      ${
+        aggregateRating.bestRating
+          ? `"bestRating": "${aggregateRating.bestRating}",`
+          : ''
+      }
+      "ratingValue": "${aggregateRating.ratingValue}"
     },
 `;
 


### PR DESCRIPTION
## Description of Change(s):

---

This PR contains a fix of #698 

There were some missing **aggregateRating** fields: `bestRating` `ratingCount`

**Docs:**
https://schema.org/aggregateRating
https://developers.google.com/search/docs/data-types/product