### PR TITLE
Fix default robots overriding

### DIFF
--- a/src/meta/__tests__/buildTags.spec.tsx
+++ b/src/meta/__tests__/buildTags.spec.tsx
@@ -1,10 +1,6 @@
 import React from 'react';
-import {
-  value getByText,
-  value cleanup,
-  value render,
-} from 'react-testing-library';
-import { value BuildTagsParams, value ImagePrevSize } from '../../types';
+import { getByText, cleanup, render } from 'react-testing-library';
+import { BuildTagsParams, ImagePrevSize } from '../../types';
 
 import buildTags from '../buildTags';
 

--- a/src/meta/__tests__/buildTags.spec.tsx
+++ b/src/meta/__tests__/buildTags.spec.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
-import { getByText, cleanup, render } from 'react-testing-library';
-import { BuildTagsParams, ImagePrevSize } from '../../types';
+import {
+  value getByText,
+  value cleanup,
+  value render,
+} from 'react-testing-library';
+import { value BuildTagsParams, value ImagePrevSize } from '../../types';
 
 import buildTags from '../buildTags';
 
@@ -884,8 +888,8 @@ it('correctly read noindex & nofollow false', () => {
     'meta[content="noindex,nofollow"]',
   );
 
-  expect(Array.from(indexfollow).length).toBe(0);
-  expect(Array.from(noindexnofollow).length).toBe(1);
+  expect(Array.from(indexfollow).length).toBe(1);
+  expect(Array.from(noindexnofollow).length).toBe(0);
 });
 
 it('correctly read all robots props', () => {

--- a/src/meta/__tests__/buildTags.spec.tsx
+++ b/src/meta/__tests__/buildTags.spec.tsx
@@ -862,7 +862,7 @@ it('correctly sets nofollow default', () => {
     'meta[content="index,follow"]',
   );
   const noindexnofollow = container.querySelectorAll(
-    'meta[content="noindex,nofollow"]',
+    'meta[content="index,nofollow"]',
   );
 
   expect(Array.from(indexfollow).length).toBe(0);

--- a/src/meta/buildTags.tsx
+++ b/src/meta/buildTags.tsx
@@ -119,13 +119,13 @@ const buildTags = (config: BuildTagsParams) => {
   }
 
   const noindex =
-    config.noindex ||
-    defaults.noindex ||
-    config.dangerouslySetAllPagesToNoIndex;
+    config.noindex != null
+      ? config.noindex
+      : defaults.noindex || config.dangerouslySetAllPagesToNoIndex;
   const nofollow =
-    config.nofollow ||
-    defaults.nofollow ||
-    config.dangerouslySetAllPagesToNoFollow;
+    config.nofollow != null
+      ? config.nofollow
+      : defaults.nofollow || config.dangerouslySetAllPagesToNoFollow;
 
   let robotsParams = '';
   if (config.robotsProps) {

--- a/src/meta/buildTags.tsx
+++ b/src/meta/buildTags.tsx
@@ -121,11 +121,11 @@ const buildTags = (config: BuildTagsParams) => {
   const noindex =
     config.noindex != null
       ? config.noindex
-      : defaults.noindex || config.dangerouslySetAllPagesToNoIndex;
+      : config.dangerouslySetAllPagesToNoIndex || defaults.noindex;
   const nofollow =
     config.nofollow != null
       ? config.nofollow
-      : defaults.nofollow || config.dangerouslySetAllPagesToNoFollow;
+      : config.dangerouslySetAllPagesToNoFollow || defaults.nofollow;
 
   let robotsParams = '';
   if (config.robotsProps) {
@@ -152,13 +152,6 @@ const buildTags = (config: BuildTagsParams) => {
   }
 
   if (noindex || nofollow) {
-    if (config.dangerouslySetAllPagesToNoIndex) {
-      defaults.noindex = true;
-    }
-    if (config.dangerouslySetAllPagesToNoFollow) {
-      defaults.nofollow = true;
-    }
-
     tagsToRender.push(
       <meta
         key="robots"


### PR DESCRIPTION
## Description of Change(s):

Fixes #727. 

`dangerouslySetAllPagesToNoIndex` in `<DefaultSeo>` had been having a priority over `noindex: false` in `<NextSeo>` of each page component. `nofollow` is also the same.

Also, the test case have expected wrong result. This PR fixes it.
