### PR TITLE
fix: missing offers field in aggregateOffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1109,8 +1109,7 @@ const Page = () => (
       instructions={[
         {
           name: 'Preheat',
-          text:
-            'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
+          text: 'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
           url: 'https://example.com/party-coffee-cake#step1',
           image: 'https://example.com/photos/party-coffee-cake/step1.jpg',
         },
@@ -1412,14 +1411,14 @@ export default Page;
 **Supported properties**
 
 | Property                        | Info                                                                                                                                                        |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
 | `applicantLocationRequirements` | The geographic location(s) in which employees may be located for to be eligible for the remote job                                                          |
 | `baseSalary`                    |                                                                                                                                                             |
 | `baseSalary.currency`           | The currency in which the monetary amount is expressed                                                                                                      |
 | `baseSalary.value`              | The value of the quantitative value. You can also provide an array of minimum and maximum salaries. .                                                       |
 | `baseSalary.unitText`           | A string indicating the unit of measurement [Base salary guideline](https://developers.google.com/search/docs/data-types/job-posting#basesalary)            |
 | `employmentType`                | Type of employment [Employement type guideline](https://developers.google.com/search/docs/data-types/job-posting#basesalary)                                |
-| `jobLocation`                   | The physical location(s) of the business where the employee will report to work (such as an office or worksite), not the location where the job was posted. |  |
+| `jobLocation`                   | The physical location(s) of the business where the employee will report to work (such as an office or worksite), not the location where the job was posted. |     |
 | `jobLocation.streetAddress`     | The street address. For example, 1600 Amphitheatre Pkwy                                                                                                     |
 | `jobLocation.addressLocality`   | The locality. For example, Mountain View.                                                                                                                   |
 | `jobLocation.addressRegion`     | The region. For example, CA.                                                                                                                                |
@@ -2055,8 +2054,7 @@ const Page = () => (
     <QAPageJsonld
       mainEntity={{
         name: 'How many ounces are there in a pound?',
-        text:
-          'I have taken up a new interest in baking and keep running across directions in ounces and pounds. I have to translate between them and was wondering how many ounces are in a pound?',
+        text: 'I have taken up a new interest in baking and keep running across directions in ounces and pounds. I have to translate between them and was wondering how many ounces are in a pound?',
         answerCount: 3,
         upvotedCount: 26,
         dateCreated: '2016-07-23T21:11Z',
@@ -2074,8 +2072,7 @@ const Page = () => (
         },
         suggestedAnswer: [
           {
-            text:
-              'Are you looking for ounces or fluid ounces? If you are looking for fluid ounces there are 15.34 fluid ounces in a pound of water.',
+            text: 'Are you looking for ounces or fluid ounces? If you are looking for fluid ounces there are 15.34 fluid ounces in a pound of water.',
             dateCreated: '2016-11-02T21:11Z',
             upvotedCount: 42,
             url: 'https://example.com/question1#suggestedAnswer1',
@@ -2452,15 +2449,13 @@ export default () => (
           instructions: [
             {
               name: 'Preheat',
-              text:
-                'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
+              text: 'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
               url: 'https://example.com/party-coffee-cake#step1',
               image: 'https://example.com/photos/party-coffee-cake/step1.jpg',
             },
             {
               name: 'Mix dry ingredients',
-              text:
-                'In a large bowl, combine flour, sugar, baking powder, and salt.',
+              text: 'In a large bowl, combine flour, sugar, baking powder, and salt.',
               url: 'https://example.com/party-coffee-cake#step2',
               image: 'https://example.com/photos/party-coffee-cake/step2.jpg',
             },
@@ -2527,15 +2522,13 @@ export default () => (
           instructions: [
             {
               name: 'Preheat',
-              text:
-                'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
+              text: 'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
               url: 'https://example.com/party-coffee-cake#step1',
               image: 'https://example.com/photos/party-coffee-cake/step1.jpg',
             },
             {
               name: 'Mix dry ingredients',
-              text:
-                'In a large bowl, combine flour, sugar, baking powder, and salt.',
+              text: 'In a large bowl, combine flour, sugar, baking powder, and salt.',
               url: 'https://example.com/party-coffee-cake#step2',
               image: 'https://example.com/photos/party-coffee-cake/step2.jpg',
             },

--- a/README.md
+++ b/README.md
@@ -1109,7 +1109,8 @@ const Page = () => (
       instructions={[
         {
           name: 'Preheat',
-          text: 'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
+          text:
+            'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
           url: 'https://example.com/party-coffee-cake#step1',
           image: 'https://example.com/photos/party-coffee-cake/step1.jpg',
         },
@@ -1411,14 +1412,14 @@ export default Page;
 **Supported properties**
 
 | Property                        | Info                                                                                                                                                        |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `applicantLocationRequirements` | The geographic location(s) in which employees may be located for to be eligible for the remote job                                                          |
 | `baseSalary`                    |                                                                                                                                                             |
 | `baseSalary.currency`           | The currency in which the monetary amount is expressed                                                                                                      |
 | `baseSalary.value`              | The value of the quantitative value. You can also provide an array of minimum and maximum salaries. .                                                       |
 | `baseSalary.unitText`           | A string indicating the unit of measurement [Base salary guideline](https://developers.google.com/search/docs/data-types/job-posting#basesalary)            |
 | `employmentType`                | Type of employment [Employement type guideline](https://developers.google.com/search/docs/data-types/job-posting#basesalary)                                |
-| `jobLocation`                   | The physical location(s) of the business where the employee will report to work (such as an office or worksite), not the location where the job was posted. |     |
+| `jobLocation`                   | The physical location(s) of the business where the employee will report to work (such as an office or worksite), not the location where the job was posted. |  |
 | `jobLocation.streetAddress`     | The street address. For example, 1600 Amphitheatre Pkwy                                                                                                     |
 | `jobLocation.addressLocality`   | The locality. For example, Mountain View.                                                                                                                   |
 | `jobLocation.addressRegion`     | The region. For example, CA.                                                                                                                                |
@@ -1773,6 +1774,7 @@ The property `aggregateOffer` is also available:
 | ------------ | ----------------------------------------------------------------------- |
 | `highPrice`  | The highest price of all offers available. Use a floating point number. |
 | `offerCount` | The number of offers for the product.                                   |
+| `offers`          | An offer to transfer some rights to an item or to provide a service. You can provide this as a single object, or an array of objects with the properties below. |
 
 More info on the product data type can be found [here](https://developers.google.com/search/docs/data-types/product).
 
@@ -2054,7 +2056,8 @@ const Page = () => (
     <QAPageJsonld
       mainEntity={{
         name: 'How many ounces are there in a pound?',
-        text: 'I have taken up a new interest in baking and keep running across directions in ounces and pounds. I have to translate between them and was wondering how many ounces are in a pound?',
+        text:
+          'I have taken up a new interest in baking and keep running across directions in ounces and pounds. I have to translate between them and was wondering how many ounces are in a pound?',
         answerCount: 3,
         upvotedCount: 26,
         dateCreated: '2016-07-23T21:11Z',
@@ -2072,7 +2075,8 @@ const Page = () => (
         },
         suggestedAnswer: [
           {
-            text: 'Are you looking for ounces or fluid ounces? If you are looking for fluid ounces there are 15.34 fluid ounces in a pound of water.',
+            text:
+              'Are you looking for ounces or fluid ounces? If you are looking for fluid ounces there are 15.34 fluid ounces in a pound of water.',
             dateCreated: '2016-11-02T21:11Z',
             upvotedCount: 42,
             url: 'https://example.com/question1#suggestedAnswer1',
@@ -2449,13 +2453,15 @@ export default () => (
           instructions: [
             {
               name: 'Preheat',
-              text: 'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
+              text:
+                'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
               url: 'https://example.com/party-coffee-cake#step1',
               image: 'https://example.com/photos/party-coffee-cake/step1.jpg',
             },
             {
               name: 'Mix dry ingredients',
-              text: 'In a large bowl, combine flour, sugar, baking powder, and salt.',
+              text:
+                'In a large bowl, combine flour, sugar, baking powder, and salt.',
               url: 'https://example.com/party-coffee-cake#step2',
               image: 'https://example.com/photos/party-coffee-cake/step2.jpg',
             },
@@ -2522,13 +2528,15 @@ export default () => (
           instructions: [
             {
               name: 'Preheat',
-              text: 'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
+              text:
+                'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
               url: 'https://example.com/party-coffee-cake#step1',
               image: 'https://example.com/photos/party-coffee-cake/step1.jpg',
             },
             {
               name: 'Mix dry ingredients',
-              text: 'In a large bowl, combine flour, sugar, baking powder, and salt.',
+              text:
+                'In a large bowl, combine flour, sugar, baking powder, and salt.',
               url: 'https://example.com/party-coffee-cake#step2',
               image: 'https://example.com/photos/party-coffee-cake/step2.jpg',
             },

--- a/README.md
+++ b/README.md
@@ -1109,8 +1109,7 @@ const Page = () => (
       instructions={[
         {
           name: 'Preheat',
-          text:
-            'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
+          text: 'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
           url: 'https://example.com/party-coffee-cake#step1',
           image: 'https://example.com/photos/party-coffee-cake/step1.jpg',
         },
@@ -1412,14 +1411,14 @@ export default Page;
 **Supported properties**
 
 | Property                        | Info                                                                                                                                                        |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- | --- |
 | `applicantLocationRequirements` | The geographic location(s) in which employees may be located for to be eligible for the remote job                                                          |
 | `baseSalary`                    |                                                                                                                                                             |
 | `baseSalary.currency`           | The currency in which the monetary amount is expressed                                                                                                      |
 | `baseSalary.value`              | The value of the quantitative value. You can also provide an array of minimum and maximum salaries. .                                                       |
 | `baseSalary.unitText`           | A string indicating the unit of measurement [Base salary guideline](https://developers.google.com/search/docs/data-types/job-posting#basesalary)            |
 | `employmentType`                | Type of employment [Employement type guideline](https://developers.google.com/search/docs/data-types/job-posting#basesalary)                                |
-| `jobLocation`                   | The physical location(s) of the business where the employee will report to work (such as an office or worksite), not the location where the job was posted. |  |
+| `jobLocation`                   | The physical location(s) of the business where the employee will report to work (such as an office or worksite), not the location where the job was posted. |     |
 | `jobLocation.streetAddress`     | The street address. For example, 1600 Amphitheatre Pkwy                                                                                                     |
 | `jobLocation.addressLocality`   | The locality. For example, Mountain View.                                                                                                                   |
 | `jobLocation.addressRegion`     | The region. For example, CA.                                                                                                                                |
@@ -1770,11 +1769,11 @@ The property `aggregateOffer` is also available:
 
 **Recommended properties**
 
-| Property     | Info                                                                    |
-| ------------ | ----------------------------------------------------------------------- |
-| `highPrice`  | The highest price of all offers available. Use a floating point number. |
-| `offerCount` | The number of offers for the product.                                   |
-| `offers`          | An offer to transfer some rights to an item or to provide a service. You can provide this as a single object, or an array of objects with the properties below. |
+| Property     | Info                                                                                                                                                            |
+| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `highPrice`  | The highest price of all offers available. Use a floating point number.                                                                                         |
+| `offerCount` | The number of offers for the product.                                                                                                                           |
+| `offers`     | An offer to transfer some rights to an item or to provide a service. You can provide this as a single object, or an array of objects with the properties below. |
 
 More info on the product data type can be found [here](https://developers.google.com/search/docs/data-types/product).
 
@@ -2056,8 +2055,7 @@ const Page = () => (
     <QAPageJsonld
       mainEntity={{
         name: 'How many ounces are there in a pound?',
-        text:
-          'I have taken up a new interest in baking and keep running across directions in ounces and pounds. I have to translate between them and was wondering how many ounces are in a pound?',
+        text: 'I have taken up a new interest in baking and keep running across directions in ounces and pounds. I have to translate between them and was wondering how many ounces are in a pound?',
         answerCount: 3,
         upvotedCount: 26,
         dateCreated: '2016-07-23T21:11Z',
@@ -2075,8 +2073,7 @@ const Page = () => (
         },
         suggestedAnswer: [
           {
-            text:
-              'Are you looking for ounces or fluid ounces? If you are looking for fluid ounces there are 15.34 fluid ounces in a pound of water.',
+            text: 'Are you looking for ounces or fluid ounces? If you are looking for fluid ounces there are 15.34 fluid ounces in a pound of water.',
             dateCreated: '2016-11-02T21:11Z',
             upvotedCount: 42,
             url: 'https://example.com/question1#suggestedAnswer1',
@@ -2453,15 +2450,13 @@ export default () => (
           instructions: [
             {
               name: 'Preheat',
-              text:
-                'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
+              text: 'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
               url: 'https://example.com/party-coffee-cake#step1',
               image: 'https://example.com/photos/party-coffee-cake/step1.jpg',
             },
             {
               name: 'Mix dry ingredients',
-              text:
-                'In a large bowl, combine flour, sugar, baking powder, and salt.',
+              text: 'In a large bowl, combine flour, sugar, baking powder, and salt.',
               url: 'https://example.com/party-coffee-cake#step2',
               image: 'https://example.com/photos/party-coffee-cake/step2.jpg',
             },
@@ -2528,15 +2523,13 @@ export default () => (
           instructions: [
             {
               name: 'Preheat',
-              text:
-                'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
+              text: 'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
               url: 'https://example.com/party-coffee-cake#step1',
               image: 'https://example.com/photos/party-coffee-cake/step1.jpg',
             },
             {
               name: 'Mix dry ingredients',
-              text:
-                'In a large bowl, combine flour, sugar, baking powder, and salt.',
+              text: 'In a large bowl, combine flour, sugar, baking powder, and salt.',
               url: 'https://example.com/party-coffee-cake#step2',
               image: 'https://example.com/photos/party-coffee-cake/step2.jpg',
             },

--- a/cypress/e2e/jsonld.spec.js
+++ b/cypress/e2e/jsonld.spec.js
@@ -231,8 +231,7 @@ describe('Validates JSON-LD For:', () => {
           '@id': 'http://davesdeptstore.example.com',
           name: "Dave's Department Store",
           description: "Dave's latest department store in San Jose, now open",
-          url:
-            'http://www.example.com/store-locator/sl/San-Jose-Westgate-Store/1427',
+          url: 'http://www.example.com/store-locator/sl/San-Jose-Westgate-Store/1427',
           telephone: '+14088717984',
           address: {
             '@type': 'PostalAddress',
@@ -470,6 +469,139 @@ describe('Validates JSON-LD For:', () => {
             ratingCount: '684',
             bestRating: '100',
           },
+          offers: [
+            {
+              '@type': 'Offer',
+              price: '119.99',
+              priceCurrency: 'USD',
+              priceValidUntil: '2020-11-05',
+              itemCondition: 'https://schema.org/UsedCondition',
+              availability: 'https://schema.org/InStock',
+              url: 'https://www.example.com/executive-anvil',
+              seller: {
+                '@type': 'Organization',
+                name: 'Executive Objects',
+              },
+            },
+            {
+              '@type': 'Offer',
+              price: '139.99',
+              priceCurrency: 'CAD',
+              priceValidUntil: '2020-09-05',
+              itemCondition: 'https://schema.org/UsedCondition',
+              availability: 'https://schema.org/InStock',
+              url: 'https://www.example.ca/executive-anvil',
+              seller: {
+                '@type': 'Organization',
+                name: 'Executive Objects',
+              },
+            },
+          ],
+        });
+      });
+  });
+
+  it('Product AggregateOffer and Offers (AggregateOffer ignored)', () => {
+    cy.visit('http://localhost:3000/product-jsonld/aggregateOfferAndOffers');
+    cy.get('head script[type="application/ld+json"]')
+      .should('have.length', 1)
+      .then(tags => {
+        const jsonLD = JSON.parse(tags[0].innerHTML);
+        expect(jsonLD).to.deep.equal({
+          '@context': 'https://schema.org/',
+          '@type': 'Product',
+          name: 'Executive Anvil',
+          offers: [
+            {
+              '@type': 'Offer',
+              price: '119.99',
+              priceCurrency: 'USD',
+              priceValidUntil: '2020-11-05',
+              itemCondition: 'https://schema.org/UsedCondition',
+              availability: 'https://schema.org/InStock',
+              url: 'https://www.example.com/executive-anvil',
+              seller: {
+                '@type': 'Organization',
+                name: 'Executive Objects',
+              },
+            },
+            {
+              '@type': 'Offer',
+              price: '139.99',
+              priceCurrency: 'CAD',
+              priceValidUntil: '2020-09-05',
+              itemCondition: 'https://schema.org/UsedCondition',
+              availability: 'https://schema.org/InStock',
+              url: 'https://www.example.ca/executive-anvil',
+              seller: {
+                '@type': 'Organization',
+                name: 'Executive Objects',
+              },
+            },
+          ],
+        });
+      });
+  });
+
+  it('Product AggregateOffer', () => {
+    cy.visit('http://localhost:3000/product-jsonld/aggregateOffer');
+    cy.get('head script[type="application/ld+json"]')
+      .should('have.length', 1)
+      .then(tags => {
+        const jsonLD = JSON.parse(tags[0].innerHTML);
+        expect(jsonLD).to.deep.equal({
+          '@context': 'https://schema.org/',
+          '@type': 'Product',
+          name: 'Executive Anvil',
+          offers: {
+            '@type': 'AggregateOffer',
+            priceCurrency: 'USD',
+            lowPrice: '119.99',
+            highPrice: '139.99',
+            offerCount: '5',
+            offers: [
+              {
+                '@type': 'Offer',
+                price: '119.99',
+                priceCurrency: 'USD',
+                priceValidUntil: '2020-11-05',
+                itemCondition: 'https://schema.org/UsedCondition',
+                availability: 'https://schema.org/InStock',
+                url: 'https://www.example.com/executive-anvil',
+                seller: {
+                  '@type': 'Organization',
+                  name: 'Executive Objects',
+                },
+              },
+              {
+                '@type': 'Offer',
+                price: '139.99',
+                priceCurrency: 'CAD',
+                priceValidUntil: '2020-09-05',
+                itemCondition: 'https://schema.org/UsedCondition',
+                availability: 'https://schema.org/InStock',
+                url: 'https://www.example.ca/executive-anvil',
+                seller: {
+                  '@type': 'Organization',
+                  name: 'Executive Objects',
+                },
+              },
+            ],
+          },
+        });
+      });
+  });
+
+  it('Product Offers', () => {
+    cy.visit('http://localhost:3000/product-jsonld/offers');
+    cy.get('head script[type="application/ld+json"]')
+      .should('have.length', 1)
+      .then(tags => {
+        const jsonLD = JSON.parse(tags[0].innerHTML);
+        expect(jsonLD).to.deep.equal({
+          '@context': 'https://schema.org/',
+          '@type': 'Product',
+          name: 'Executive Anvil',
           offers: [
             {
               '@type': 'Offer',
@@ -967,8 +1099,7 @@ describe('Validates JSON-LD For:', () => {
             {
               '@type': 'HowToStep',
               name: 'Preheat',
-              text:
-                'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
+              text: 'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
               url: 'https://example.com/party-coffee-cake#step1',
               image: 'https://example.com/photos/party-coffee-cake/step1.jpg',
             },
@@ -1069,8 +1200,7 @@ describe('Validates JSON-LD For:', () => {
           mainEntity: {
             '@type': 'Question',
             name: 'How many ounces are there in a pound?',
-            text:
-              'I have taken up a new interest in baking and keep running across directions in ounces and pounds. I have to translate between them and was wondering how many ounces are in a pound?',
+            text: 'I have taken up a new interest in baking and keep running across directions in ounces and pounds. I have to translate between them and was wondering how many ounces are in a pound?',
             answerCount: 3,
             upvoteCount: 26,
             dateCreated: '2016-07-23T21:11Z',
@@ -1092,8 +1222,7 @@ describe('Validates JSON-LD For:', () => {
             suggestedAnswer: [
               {
                 '@type': 'Answer',
-                text:
-                  'Are you looking for ounces or fluid ounces? If you are looking for fluid ounces there are 15.34 fluid ounces in a pound of water.',
+                text: 'Are you looking for ounces or fluid ounces? If you are looking for fluid ounces there are 15.34 fluid ounces in a pound of water.',
                 dateCreated: '2016-11-02T21:11Z',
                 upvoteCount: 42,
                 url: 'https://example.com/question1#suggestedAnswer1',
@@ -1104,8 +1233,7 @@ describe('Validates JSON-LD For:', () => {
               },
               {
                 '@type': 'Answer',
-                text:
-                  "I can't remember exactly, but I think 18 ounces in a lb. You might want to double check that.",
+                text: "I can't remember exactly, but I think 18 ounces in a lb. You might want to double check that.",
                 dateCreated: '2016-11-06T21:11Z',
                 upvoteCount: 0,
                 url: 'https://example.com/question1#suggestedAnswer2',
@@ -1411,8 +1539,7 @@ describe('Validates JSON-LD For:', () => {
                   {
                     '@type': 'HowToStep',
                     name: 'Preheat',
-                    text:
-                      'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
+                    text: 'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
                     url: 'https://example.com/party-coffee-cake#step1',
                     image:
                       'https://example.com/photos/party-coffee-cake/step1.jpg',
@@ -1420,8 +1547,7 @@ describe('Validates JSON-LD For:', () => {
                   {
                     '@type': 'HowToStep',
                     name: 'Mix dry ingredients',
-                    text:
-                      'In a large bowl, combine flour, sugar, baking powder, and salt.',
+                    text: 'In a large bowl, combine flour, sugar, baking powder, and salt.',
                     url: 'https://example.com/party-coffee-cake#step2',
                     image:
                       'https://example.com/photos/party-coffee-cake/step2.jpg',
@@ -1506,8 +1632,7 @@ describe('Validates JSON-LD For:', () => {
                   {
                     '@type': 'HowToStep',
                     name: 'Preheat',
-                    text:
-                      'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
+                    text: 'Preheat the oven to 350 degrees F. Grease and flour a 9x9 inch pan.',
                     url: 'https://example.com/party-coffee-cake#step1',
                     image:
                       'https://example.com/photos/party-coffee-cake/step1.jpg',
@@ -1515,8 +1640,7 @@ describe('Validates JSON-LD For:', () => {
                   {
                     '@type': 'HowToStep',
                     name: 'Mix dry ingredients',
-                    text:
-                      'In a large bowl, combine flour, sugar, baking powder, and salt.',
+                    text: 'In a large bowl, combine flour, sugar, baking powder, and salt.',
                     url: 'https://example.com/party-coffee-cake#step2',
                     image:
                       'https://example.com/photos/party-coffee-cake/step2.jpg',

--- a/cypress/e2e/jsonld.spec.js
+++ b/cypress/e2e/jsonld.spec.js
@@ -592,6 +592,40 @@ describe('Validates JSON-LD For:', () => {
       });
   });
 
+  it('Product AggregateOffer (single)', () => {
+    cy.visit('http://localhost:3000/product-jsonld/aggregateOffer2');
+    cy.get('head script[type="application/ld+json"]')
+      .should('have.length', 1)
+      .then(tags => {
+        const jsonLD = JSON.parse(tags[0].innerHTML);
+        expect(jsonLD).to.deep.equal({
+          '@context': 'https://schema.org/',
+          '@type': 'Product',
+          name: 'Executive Anvil',
+          offers: {
+            '@type': 'AggregateOffer',
+            priceCurrency: 'USD',
+            lowPrice: '119.99',
+            highPrice: '139.99',
+            offerCount: '5',
+            offers: {
+              '@type': 'Offer',
+              price: '119.99',
+              priceCurrency: 'USD',
+              priceValidUntil: '2020-11-05',
+              itemCondition: 'https://schema.org/UsedCondition',
+              availability: 'https://schema.org/InStock',
+              url: 'https://www.example.com/executive-anvil',
+              seller: {
+                '@type': 'Organization',
+                name: 'Executive Objects',
+              },
+            },
+          },
+        });
+      });
+  });
+
   it('Product Offers', () => {
     cy.visit('http://localhost:3000/product-jsonld/offers');
     cy.get('head script[type="application/ld+json"]')

--- a/cypress/schemas/product-schema.js
+++ b/cypress/schemas/product-schema.js
@@ -62,6 +62,28 @@ const product100 = {
         ...aggregateRating100.schema,
         see: aggregateRating100,
       },
+      aggregateOffer: {
+        priceCurrency: {
+          type: 'string',
+          description: 'The product price currency',
+        },
+        lowPrice: {
+          type: 'string',
+          description: 'The lowest product price',
+        },
+        highPrice: {
+          type: 'string',
+          description: 'The highest product price',
+        },
+        offerCount: {
+          type: 'string',
+          description: 'The product offers count',
+        },
+        offers: {
+          ...offers101.schema,
+          see: offers101,
+        },
+      },
       offers: {
         ...offers101.schema,
         see: offers101,
@@ -111,6 +133,36 @@ const product100 = {
       '@type': 'AggregateRating',
       ratingValue: '4.4',
       reviewCount: '89',
+    },
+    aggregateOffer: {
+      priceCurrency: 'USD',
+      lowPrice: '119.99',
+      highPrice: '139.99',
+      offerCount: '5',
+      offers: [
+        {
+          price: '119.99',
+          priceCurrency: 'USD',
+          priceValidUntil: '2020-11-05',
+          itemCondition: 'https://schema.org/UsedCondition',
+          availability: 'https://schema.org/InStock',
+          url: 'https://www.example.com/executive-anvil',
+          seller: {
+            name: 'Executive Objects',
+          },
+        },
+        {
+          price: '139.99',
+          priceCurrency: 'CAD',
+          priceValidUntil: '2020-09-05',
+          itemCondition: 'https://schema.org/UsedCondition',
+          availability: 'https://schema.org/InStock',
+          url: 'https://www.example.ca/executive-anvil',
+          seller: {
+            name: 'Executive Objects',
+          },
+        },
+      ],
     },
     offers: [
       {

--- a/e2e/components/links.tsx
+++ b/e2e/components/links.tsx
@@ -58,6 +58,21 @@ const Links = () => (
         <a>Carousel Recipe JSON-LD</a>
       </Link>
     </li>
+    <li>
+      <Link href="/product-jsonld/aggregateOffer">
+        <a>Product JSON-LD AggregateOffer</a>
+      </Link>
+    </li>
+    <li>
+      <Link href="/product-jsonld/offers">
+        <a>Product JSON-LD Offers</a>
+      </Link>
+    </li>
+    <li>
+      <Link href="/product-jsonld/aggregateOfferAndOffers">
+        <a>Product JSON-LD AggregateOffer and Offers</a>
+      </Link>
+    </li>
   </ul>
 );
 

--- a/e2e/pages/product-jsonld/aggregateOffer.tsx
+++ b/e2e/pages/product-jsonld/aggregateOffer.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { ProductJsonLd } from '../../..';
+import Links from '../../components/links';
+
+const AggregateOffer = () => (
+  <>
+    <h1>Product JSON-LD AggregateOffer</h1>
+
+    <ProductJsonLd
+      productName="Executive Anvil"
+      aggregateOffer={{
+        priceCurrency: 'USD',
+        lowPrice: '119.99',
+        highPrice: '139.99',
+        offerCount: '5',
+        offers: [
+          {
+            price: '119.99',
+            priceCurrency: 'USD',
+            priceValidUntil: '2020-11-05',
+            itemCondition: 'https://schema.org/UsedCondition',
+            availability: 'https://schema.org/InStock',
+            url: 'https://www.example.com/executive-anvil',
+            seller: {
+              name: 'Executive Objects',
+            },
+          },
+          {
+            price: '139.99',
+            priceCurrency: 'CAD',
+            priceValidUntil: '2020-09-05',
+            itemCondition: 'https://schema.org/UsedCondition',
+            availability: 'https://schema.org/InStock',
+            url: 'https://www.example.ca/executive-anvil',
+            seller: {
+              name: 'Executive Objects',
+            },
+          },
+        ],
+      }}
+    />
+
+    <Links />
+  </>
+);
+
+export default AggregateOffer;

--- a/e2e/pages/product-jsonld/aggregateOffer2.tsx
+++ b/e2e/pages/product-jsonld/aggregateOffer2.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { ProductJsonLd } from '../../..';
+import Links from '../../components/links';
+
+const AggregateOffer2 = () => (
+  <>
+    <h1>Product JSON-LD AggregateOffer2</h1>
+
+    <ProductJsonLd
+      productName="Executive Anvil"
+      aggregateOffer={{
+        priceCurrency: 'USD',
+        lowPrice: '119.99',
+        highPrice: '139.99',
+        offerCount: '5',
+        offers: {
+          price: '119.99',
+          priceCurrency: 'USD',
+          priceValidUntil: '2020-11-05',
+          itemCondition: 'https://schema.org/UsedCondition',
+          availability: 'https://schema.org/InStock',
+          url: 'https://www.example.com/executive-anvil',
+          seller: {
+            name: 'Executive Objects',
+          },
+        },
+      }}
+    />
+
+    <Links />
+  </>
+);
+
+export default AggregateOffer2;

--- a/e2e/pages/product-jsonld/aggregateOfferAndOffers.tsx
+++ b/e2e/pages/product-jsonld/aggregateOfferAndOffers.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { ProductJsonLd } from '../../..';
+import Links from '../../components/links';
+
+const AggregateOfferAndOffers = () => (
+  <>
+    <h1>Product JSON-LD AggregateOffer and Offers</h1>
+
+    <ProductJsonLd
+      productName="Executive Anvil"
+      aggregateOffer={{
+        priceCurrency: 'USD',
+        lowPrice: '119.99',
+        highPrice: '139.99',
+        offerCount: '5',
+        offers: [
+          {
+            price: '119.99',
+            priceCurrency: 'USD',
+            priceValidUntil: '2020-11-05',
+            itemCondition: 'https://schema.org/UsedCondition',
+            availability: 'https://schema.org/InStock',
+            url: 'https://www.example.com/executive-anvil',
+            seller: {
+              name: 'Executive Objects',
+            },
+          },
+          {
+            price: '139.99',
+            priceCurrency: 'CAD',
+            priceValidUntil: '2020-09-05',
+            itemCondition: 'https://schema.org/UsedCondition',
+            availability: 'https://schema.org/InStock',
+            url: 'https://www.example.ca/executive-anvil',
+            seller: {
+              name: 'Executive Objects',
+            },
+          },
+        ],
+      }}
+      offers={[
+        {
+          price: '119.99',
+          priceCurrency: 'USD',
+          priceValidUntil: '2020-11-05',
+          itemCondition: 'https://schema.org/UsedCondition',
+          availability: 'https://schema.org/InStock',
+          url: 'https://www.example.com/executive-anvil',
+          seller: {
+            name: 'Executive Objects',
+          },
+        },
+        {
+          price: '139.99',
+          priceCurrency: 'CAD',
+          priceValidUntil: '2020-09-05',
+          itemCondition: 'https://schema.org/UsedCondition',
+          availability: 'https://schema.org/InStock',
+          url: 'https://www.example.ca/executive-anvil',
+          seller: {
+            name: 'Executive Objects',
+          },
+        },
+      ]}
+    />
+
+    <Links />
+  </>
+);
+
+export default AggregateOfferAndOffers;

--- a/e2e/pages/product-jsonld/offers.tsx
+++ b/e2e/pages/product-jsonld/offers.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { ProductJsonLd } from '../../..';
+import Links from '../../components/links';
+
+const Offers = () => (
+  <>
+    <h1>Product JSON-LD Offers</h1>
+
+    <ProductJsonLd
+      productName="Executive Anvil"
+      offers={[
+        {
+          price: '119.99',
+          priceCurrency: 'USD',
+          priceValidUntil: '2020-11-05',
+          itemCondition: 'https://schema.org/UsedCondition',
+          availability: 'https://schema.org/InStock',
+          url: 'https://www.example.com/executive-anvil',
+          seller: {
+            name: 'Executive Objects',
+          },
+        },
+        {
+          price: '139.99',
+          priceCurrency: 'CAD',
+          priceValidUntil: '2020-09-05',
+          itemCondition: 'https://schema.org/UsedCondition',
+          availability: 'https://schema.org/InStock',
+          url: 'https://www.example.ca/executive-anvil',
+          seller: {
+            name: 'Executive Objects',
+          },
+        },
+      ]}
+    />
+
+    <Links />
+  </>
+);
+
+export default Offers;

--- a/src/jsonld/product.tsx
+++ b/src/jsonld/product.tsx
@@ -166,7 +166,7 @@ const ProductJsonLd: FC<ProductJsonLdProps> = ({
   const jslonld = `{
     "@context": "https://schema.org/",
     "@type": "Product",
-    "image":${formatIfArray(images)},
+    ${images.length ? `"image":${formatIfArray(images)},` : ''}
     ${description ? `"description": "${description}",` : ''}
     ${mpn ? `"mpn": "${mpn}",` : ''}
     ${sku ? `"sku": "${sku}",` : ''}
@@ -188,14 +188,26 @@ const ProductJsonLd: FC<ProductJsonLdProps> = ({
     ${releaseDate ? `"releaseDate": "${releaseDate}",` : ''}
     ${purchaseDate ? `"purchaseDate": "${purchaseDate}",` : ''}
     ${award ? `"award": "${award}",` : ''}
-    "manufacturer": {
-      "@type": "Organization",
-      "name": "${manufacturerName}",
-      "logo": {
-        "@type": "ImageObject",
-        "url": "${manufacturerLogo}"
-      }
-    },
+    ${
+      manufacturerName
+        ? `
+        "manufacturer": {
+          "@type": "Organization",
+          ${
+            manufacturerLogo
+              ? `
+              "logo": {
+                "@type": "ImageObject",
+                "url": "${manufacturerLogo}"
+              },
+              `
+              : ''
+          }
+          "name": "${manufacturerName}"
+        },
+        `
+        : ''
+    }
     ${
       offers
         ? `"offers": ${

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,6 +67,7 @@ export type AggregateOffer = {
   lowPrice: string;
   highPrice?: string;
   offerCount?: string;
+  offers?: Offers | Offers[];
 };
 
 export interface OpenGraphVideoActors {

--- a/src/utils/buildAggregateOffer.ts
+++ b/src/utils/buildAggregateOffer.ts
@@ -1,4 +1,5 @@
 import { AggregateOffer } from '../types';
+import { buildOffers } from './buildOffers';
 
 export const buildAggregateOffer = (offer: AggregateOffer) => `
   {
@@ -6,6 +7,15 @@ export const buildAggregateOffer = (offer: AggregateOffer) => `
     "priceCurrency": "${offer.priceCurrency}",
     ${offer.highPrice ? `"highPrice": "${offer.highPrice}",` : ''}
     ${offer.offerCount ? `"offerCount": "${offer.offerCount}",` : ''}
+    ${
+      offer.offers
+        ? `"offers": ${
+            Array.isArray(offer.offers)
+              ? `[${offer.offers.map(offer => `${buildOffers(offer)}`)}]`
+              : buildOffers(offer.offers)
+          },`
+        : ''
+    }
     "lowPrice": "${offer.lowPrice}"
   }
 `;


### PR DESCRIPTION
Closes: #766.

## Description of Change(s):

- New test to check if both `offers` and `aggregateOffer` are provided in product ld-json, the `aggregateOffer` is ignored.
- New test to check product ld-json `aggregateOffer` separately
- New test to check product ld-json `offers` separately
- This PR also includes a fix of not set fields show up which are `images` and `manufacturer` in product ld-json in the output.
