### PR TITLE
Minify JSON-LD markup result

### DIFF
--- a/src/utils/markup.tsx
+++ b/src/utils/markup.tsx
@@ -1,3 +1,3 @@
-const markup = (jsonld: string) => ({ __html: jsonld.split("\n").map(e => e.trim()).join("") });
+const markup = (jsonld: string) => ({ __html: JSON.stringify(JSON.parse(jsonld)) });
 
 export default markup;

--- a/src/utils/markup.tsx
+++ b/src/utils/markup.tsx
@@ -1,3 +1,3 @@
-const markup = (jsonld: string) => ({ __html: jsonld });
+const markup = (jsonld: string) => ({ __html: jsonld.split("\n").map(e => e.trim()).join("") });
 
 export default markup;


### PR DESCRIPTION
## Description of Change(s):

JSON-LD Markup can be minified without any effect on parsing capabilities. This also solves the extra newlines issues present in most markups.