### PR TITLE
Google structured data on article version 2

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,4 @@
+{
+    "presets": ["next/babel"],
+    "plugins": []
+}

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": ["eslint-config-next"],
+  "extends": ["next/babel", "eslint-config-next"],
   "rules": {
     "react/no-array-index-key": 0,
     "no-prototype-builtins": 0,

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules
 *.log
 .next
 .history
+.yarn*
 dist
 cypress/videos
 coverage

--- a/README.md
+++ b/README.md
@@ -998,6 +998,51 @@ const Page = () => (
 export default Page;
 ```
 
+If you need to add an URL to link to the auhtors pages the [new Google Structured Data for Article](https://searchengineland.com/google-adds-author-url-property-to-uniquely-identify-authors-of-articles-351131) is also available.
+
+```jsx
+import { ArticleJsonLd } from 'next-seo';
+
+const Page = () => (
+  <>
+    <h1>Article JSON-LD</h1>
+    <ArticleJsonLd
+      url="https://example.com/article"
+      title="Article headline"
+      images={[
+        'https://example.com/photos/1x1/photo.jpg',
+        'https://example.com/photos/4x3/photo.jpg',
+        'https://example.com/photos/16x9/photo.jpg',
+      ]}
+      datePublished="2015-02-05T08:00:00+08:00"
+      dateModified="2015-02-05T09:00:00+08:00"
+      author={
+        ([
+          (type: 'Person'),
+          (name: 'Jane Blogs'),
+          (url: 'https://www.example.com/author/janeblogs123'),
+        ],
+        [
+          (type: 'Person'),
+          (name: 'Mary Stone'),
+          (url: 'https://www.example.com/author/marystone123'),
+        ],
+        [
+          (type: 'Organization'),
+          (name: 'Acme'),
+          (url: 'https://www.example.com/organization/acme123'),
+        ])
+      }
+      publisherName="Gary Meehan"
+      publisherLogo="https://www.example.com/photos/logo.jpg"
+      description="This is a mighty good description of this article."
+    />
+  </>
+);
+
+export default Page;
+```
+
 ### Breadcrumb
 
 ```jsx

--- a/README.md
+++ b/README.md
@@ -998,7 +998,7 @@ const Page = () => (
 export default Page;
 ```
 
-If you need to add an URL to link to the auhtors pages the [new Google Structured Data for Article](https://searchengineland.com/google-adds-author-url-property-to-uniquely-identify-authors-of-articles-351131) is also available.
+If you need to add an URL to link to the authors pages the [new Google Structured Data for Article](https://searchengineland.com/google-adds-author-url-property-to-uniquely-identify-authors-of-articles-351131) is also available.
 
 ```jsx
 import { ArticleJsonLd } from 'next-seo';

--- a/cypress/e2e/jsonld.spec.js
+++ b/cypress/e2e/jsonld.spec.js
@@ -3,29 +3,31 @@ import schemas from '../schemas';
 
 const expectedJSONResults = 23;
 
-const articleLdJsonIndex = 0;
-const breadcrumbLdJsonIndex = 1;
-const blogLdJsonIndex = 2;
-const courseLdJsonIndex = 3;
-const localBusinessLdJsonIndex = 4;
-const logoLdJsonIndex = 5;
-const logoLdSecondJsonIndex = 6;
-const productLdJsonIndex = 7;
-const socialProfileLdJsonIndex = 8;
-const corporateContactIndex = 9;
-const newsarticleLdJsonIndex = 10;
-const faqPageLdJsonIndex = 11;
-const jobPostingLdJsonIndex = 12;
-const jobPostingLdSecondJsonIndex = 13;
-const eventLdJsonIndex = 14;
-const datasetLdJsonIndex = 15;
-const recipeLdJsonIndex = 16;
-const siteLinksSearchBoxLdJsonIndex = 17;
-const qaPageLdJsonIndex = 18;
-const softwareAppJsonIndex = 19;
-const collectionPageLdJsonIndex = 20;
-const profilePageLdJsonIndex = 21;
-const videoGameLdJsonIndex = 22;
+const [
+  articleLdJsonIndex,
+  breadcrumbLdJsonIndex,
+  blogLdJsonIndex,
+  courseLdJsonIndex,
+  localBusinessLdJsonIndex,
+  logoLdJsonIndex,
+  logoLdSecondJsonIndex,
+  productLdJsonIndex,
+  socialProfileLdJsonIndex,
+  corporateContactIndex,
+  newsarticleLdJsonIndex,
+  faqPageLdJsonIndex,
+  jobPostingLdJsonIndex,
+  jobPostingLdSecondJsonIndex,
+  eventLdJsonIndex,
+  datasetLdJsonIndex,
+  recipeLdJsonIndex,
+  siteLinksSearchBoxLdJsonIndex,
+  qaPageLdJsonIndex,
+  softwareAppJsonIndex,
+  collectionPageLdJsonIndex,
+  profilePageLdJsonIndex,
+  videoGameLdJsonIndex,
+] = [...Array(expectedJSONResults).keys()];
 
 describe('Validates JSON-LD For:', () => {
   it('Article', () => {
@@ -63,10 +65,17 @@ describe('Validates JSON-LD For:', () => {
             {
               '@type': 'Person',
               name: 'Jane Blogs',
+              url: 'https://www.example.com/author/janeblogs123',
             },
             {
               '@type': 'Person',
               name: 'Mary Stone',
+              url: 'https://www.example.com/author/marystone123',
+            },
+            {
+              '@type': 'Organization',
+              name: 'Acme',
+              url: 'https://www.example.com/organization/acme123',
             },
           ],
           publisher: {

--- a/cypress/e2e/jsonld.spec.js
+++ b/cypress/e2e/jsonld.spec.js
@@ -1,10 +1,11 @@
 import { assertSchema } from '@cypress/schema-tools';
 import schemas from '../schemas';
 
-const expectedJSONResults = 23;
+const expectedJSONResults = 24;
 
 const [
   articleLdJsonIndex,
+  articleLdBackwardCompatibleJsonIndex,
   breadcrumbLdJsonIndex,
   blogLdJsonIndex,
   courseLdJsonIndex,
@@ -45,8 +46,8 @@ describe('Validates JSON-LD For:', () => {
     cy.get('head script[type="application/ld+json"]')
       .should('have.length', expectedJSONResults)
       .then(tags => {
-        const jsonLD = JSON.parse(tags[articleLdJsonIndex].innerHTML);
-        expect(jsonLD).to.deep.equal({
+        const jsonLD1 = JSON.parse(tags[articleLdJsonIndex].innerHTML);
+        expect(jsonLD1).to.deep.equal({
           '@context': 'https://schema.org',
           '@type': 'Article',
           mainEntityOfPage: {
@@ -76,6 +77,44 @@ describe('Validates JSON-LD For:', () => {
               '@type': 'Organization',
               name: 'Acme',
               url: 'https://www.example.com/organization/acme123',
+            },
+          ],
+          publisher: {
+            '@type': 'Organization',
+            name: 'Gary Meehan',
+            logo: {
+              '@type': 'ImageObject',
+              url: 'https://www.example.com/photos/logo.jpg',
+            },
+          },
+          description: 'This is a mighty good description of this article.',
+        });
+        const jsonLD2 = JSON.parse(
+          tags[articleLdBackwardCompatibleJsonIndex].innerHTML,
+        );
+        expect(jsonLD2).to.deep.equal({
+          '@context': 'https://schema.org',
+          '@type': 'Article',
+          mainEntityOfPage: {
+            '@type': 'WebPage',
+            '@id': 'https://example.com/article',
+          },
+          headline: 'Article headline backward compatible',
+          image: [
+            'https://example.com/photos/1x1/photo.jpg',
+            'https://example.com/photos/4x3/photo.jpg',
+            'https://example.com/photos/16x9/photo.jpg',
+          ],
+          datePublished: '2015-02-05T08:00:00+08:00',
+          dateModified: '2015-02-05T09:00:00+08:00',
+          author: [
+            {
+              '@type': 'Person',
+              name: 'Jane Blogs',
+            },
+            {
+              '@type': 'Person',
+              name: 'Mary Stone',
             },
           ],
           publisher: {

--- a/cypress/schemas/article-schema.js
+++ b/cypress/schemas/article-schema.js
@@ -46,12 +46,17 @@ const author100 = {
         type: 'string',
         description: 'Name of the author',
       },
+      url: {
+        type: 'string',
+        description: 'Url of the authors page',
+      },
     },
     required: true,
     additionalProperties: false,
     example: {
       '@type': 'Person',
       name: 'Jane Blogs',
+      url: 'https://www.example.com/author/janeblogs123',
     },
   },
 };
@@ -196,6 +201,7 @@ const article100 = {
     author: {
       '@type': 'Person',
       name: 'Jane Blogs',
+      url: 'https://www.example.com/author/janeblogs123',
     },
     publisher: {
       '@type': 'Organization',

--- a/e2e/pages/jsonld.tsx
+++ b/e2e/pages/jsonld.tsx
@@ -37,7 +37,23 @@ const JsonLD = () => (
       ]}
       datePublished="2015-02-05T08:00:00+08:00"
       dateModified="2015-02-05T09:00:00+08:00"
-      authorName={['Jane Blogs', 'Mary Stone']}
+      author={[
+        {
+          type: 'Person',
+          name: 'Jane Blogs',
+          url: 'https://www.example.com/author/janeblogs123',
+        },
+        {
+          type: 'Person',
+          name: 'Mary Stone',
+          url: 'https://www.example.com/author/marystone123',
+        },
+        {
+          type: 'Organization',
+          name: 'Acme',
+          url: 'https://www.example.com/organization/acme123',
+        },
+      ]}
       publisherName="Gary Meehan"
       publisherLogo="https://www.example.com/photos/logo.jpg"
       description="This is a mighty good description of this article."

--- a/e2e/pages/jsonld.tsx
+++ b/e2e/pages/jsonld.tsx
@@ -28,6 +28,7 @@ const JsonLD = () => (
   <>
     <h1>All JSON-LD</h1>
     <ArticleJsonLd
+      keyOverride="article-with-author-url"
       url="https://example.com/article"
       title="Article headline"
       images={[
@@ -54,6 +55,23 @@ const JsonLD = () => (
           url: 'https://www.example.com/organization/acme123',
         },
       ]}
+      publisherName="Gary Meehan"
+      publisherLogo="https://www.example.com/photos/logo.jpg"
+      description="This is a mighty good description of this article."
+    />
+
+    <ArticleJsonLd
+      keyOverride="article-with-author-name-list"
+      url="https://example.com/article"
+      title="Article headline backward compatible"
+      images={[
+        'https://example.com/photos/1x1/photo.jpg',
+        'https://example.com/photos/4x3/photo.jpg',
+        'https://example.com/photos/16x9/photo.jpg',
+      ]}
+      datePublished="2015-02-05T08:00:00+08:00"
+      dateModified="2015-02-05T09:00:00+08:00"
+      authorName={['Jane Blogs', 'Mary Stone']}
       publisherName="Gary Meehan"
       publisherLogo="https://www.example.com/photos/logo.jpg"
       description="This is a mighty good description of this article."

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "homepage": "https://github.com/garmeeh/next-seo#readme",
   "devDependencies": {
     "@cypress/schema-tools": "^4.7.1",
-    "@types/jest": "^26.0.0",
+    "@types/jest": "^27.0.1",
     "@types/node": "^15.0.1",
     "@types/react": "^17.0.1",
     "@types/react-dom": "^17.0.1",

--- a/src/jsonld/article.tsx
+++ b/src/jsonld/article.tsx
@@ -13,8 +13,8 @@ export interface ArticleJsonLdProps {
   images: ReadonlyArray<string>;
   datePublished: string;
   dateModified?: string;
-  authorName: string | string[];
-  author: Author | Author[];
+  authorName?: string | string[];
+  author?: Author | Author[];
   description: string;
   publisherName: string;
   publisherLogo: string;
@@ -33,7 +33,7 @@ const ArticleJsonLd: FC<ArticleJsonLdProps> = ({
   publisherName,
   publisherLogo,
 }) => {
-  const jslonld = JSON.stringify(
+  const jsonld = JSON.stringify(
     {
       '@context': 'https://schema.org',
       '@type': 'Article',
@@ -64,7 +64,7 @@ const ArticleJsonLd: FC<ArticleJsonLdProps> = ({
     <Head>
       <script
         type="application/ld+json"
-        dangerouslySetInnerHTML={markup(jslonld)}
+        dangerouslySetInnerHTML={markup(jsonld)}
         key={`jsonld-article${keyOverride ? `-${keyOverride}` : ''}`}
       />
     </Head>

--- a/src/jsonld/article.tsx
+++ b/src/jsonld/article.tsx
@@ -2,7 +2,9 @@ import React, { FC } from 'react';
 import Head from 'next/head';
 
 import markup from '../utils/markup';
-import formatAuthorName from '../utils/formatAuthorName';
+import { buildAuthor } from '../utils/buildArticle';
+
+import { Author } from '../types';
 
 export interface ArticleJsonLdProps {
   keyOverride?: string;
@@ -12,6 +14,7 @@ export interface ArticleJsonLdProps {
   datePublished: string;
   dateModified?: string;
   authorName: string | string[];
+  author: Author | Author[];
   description: string;
   publisherName: string;
   publisherLogo: string;
@@ -25,34 +28,37 @@ const ArticleJsonLd: FC<ArticleJsonLdProps> = ({
   datePublished,
   dateModified = null,
   authorName,
+  author,
   description,
   publisherName,
   publisherLogo,
 }) => {
-  const jslonld = `{
-    "@context": "https://schema.org",
-    "@type": "Article",
-    "mainEntityOfPage": {
-      "@type": "WebPage",
-      "@id": "${url}"
+  const jslonld = JSON.stringify(
+    {
+      '@context': 'https://schema.org',
+      '@type': 'Article',
+      mainEntityOfPage: {
+        '@type': 'WebPage',
+        '@id': url,
+      },
+      headline: title,
+      image: images.map(image => image),
+      datePublished: datePublished,
+      dateModified: dateModified || datePublished,
+      author: buildAuthor(author || authorName),
+      publisher: {
+        '@type': 'Organization',
+        name: publisherName,
+        logo: {
+          '@type': 'ImageObject',
+          url: publisherLogo,
+        },
+      },
+      description: description,
     },
-    "headline": "${title}",
-    "image": [
-      ${images.map(image => `"${image}"`)}
-     ],
-    "datePublished": "${datePublished}",
-    "dateModified": "${dateModified || datePublished}",
-    "author": ${formatAuthorName(authorName)},
-    "publisher": {
-      "@type": "Organization",
-      "name": "${publisherName}",
-      "logo": {
-        "@type": "ImageObject",
-        "url": "${publisherLogo}"
-      }
-    },
-    "description": "${description}"
-  }`;
+    null,
+    2,
+  );
 
   return (
     <Head>

--- a/src/types.ts
+++ b/src/types.ts
@@ -210,6 +210,14 @@ export type ReviewRating = {
 export type Author = {
   type: string;
   name: string;
+  url: string;
+};
+
+export const isAuthor = (author: Author | string): author is Author => {
+  return (
+    (author as Author).name !== undefined &&
+    (author as Author).url !== undefined
+  );
 };
 
 export type Publisher = {

--- a/src/utils/__tests__/buildArticle.spec.tsx
+++ b/src/utils/__tests__/buildArticle.spec.tsx
@@ -1,6 +1,12 @@
 import { formatAuthorName, buildAuthor } from '../buildArticle';
 import { Author } from '../../types';
 
+it('supports no or empty authors', () => {
+  expect(buildAuthor(null)).toStrictEqual('');
+  expect(buildAuthor(undefined)).toStrictEqual('');
+  expect(buildAuthor([])).toStrictEqual([]);
+});
+
 it('format an author from a string', () => {
   expect(formatAuthorName('John Doe')).toHaveProperty('name', 'John Doe');
   expect(formatAuthorName('John Doe')).toHaveProperty('@type', 'Person');
@@ -74,6 +80,23 @@ it('build an author from an array of Author', () => {
       '@type': 'Organization',
       name: 'Acme',
       url: 'https://www.example.com/organization/acme123',
+    },
+  ]);
+});
+
+it('build an author from a string or an array of string', () => {
+  expect(buildAuthor('John Doe')).toStrictEqual({
+    '@type': 'Person',
+    name: 'John Doe',
+  });
+  expect(buildAuthor(['John Doe', 'Jane Roe'])).toStrictEqual([
+    {
+      '@type': 'Person',
+      name: 'John Doe',
+    },
+    {
+      '@type': 'Person',
+      name: 'Jane Roe',
     },
   ]);
 });

--- a/src/utils/__tests__/buildArticle.spec.tsx
+++ b/src/utils/__tests__/buildArticle.spec.tsx
@@ -1,0 +1,79 @@
+import { formatAuthorName, buildAuthor } from '../buildArticle';
+import { Author } from '../../types';
+
+it('format an author from a string', () => {
+  expect(formatAuthorName('John Doe')).toHaveProperty('name', 'John Doe');
+  expect(formatAuthorName('John Doe')).toHaveProperty('@type', 'Person');
+});
+
+it('build an author from an Author', () => {
+  const author1: Author = {
+    type: 'Person',
+    name: 'John Doe',
+    url: 'https://www.example.com/author/johndoe123',
+  };
+  const author2: Author = {
+    type: 'Person',
+    name: 'Jane Roe',
+    url: 'https://www.example.com/author/janeroe123',
+  };
+  const author3: Author = {
+    type: 'Organization',
+    name: 'Acme',
+    url: 'https://www.example.com/organization/acme123',
+  };
+  expect(buildAuthor(author1)).toHaveProperty('@type', 'Person');
+  expect(buildAuthor(author2)).toHaveProperty('@type', 'Person');
+  expect(buildAuthor(author3)).toHaveProperty('@type', 'Organization');
+  expect(buildAuthor(author1)).toHaveProperty('name', 'John Doe');
+  expect(buildAuthor(author2)).toHaveProperty('name', 'Jane Roe');
+  expect(buildAuthor(author3)).toHaveProperty('name', 'Acme');
+  expect(buildAuthor(author1)).toHaveProperty(
+    'url',
+    'https://www.example.com/author/johndoe123',
+  );
+  expect(buildAuthor(author2)).toHaveProperty(
+    'url',
+    'https://www.example.com/author/janeroe123',
+  );
+  expect(buildAuthor(author3)).toHaveProperty(
+    'url',
+    'https://www.example.com/organization/acme123',
+  );
+});
+it('build an author from an array of Author', () => {
+  const authors: Author[] = [
+    {
+      type: 'Person',
+      name: 'John Doe',
+      url: 'https://www.example.com/author/johndoe123',
+    },
+    {
+      type: 'Person',
+      name: 'Jane Roe',
+      url: 'https://www.example.com/author/janeroe123',
+    },
+    {
+      type: 'Organization',
+      name: 'Acme',
+      url: 'https://www.example.com/organization/acme123',
+    },
+  ];
+  expect(buildAuthor(authors)).toStrictEqual([
+    {
+      '@type': 'Person',
+      name: 'John Doe',
+      url: 'https://www.example.com/author/johndoe123',
+    },
+    {
+      '@type': 'Person',
+      name: 'Jane Roe',
+      url: 'https://www.example.com/author/janeroe123',
+    },
+    {
+      '@type': 'Organization',
+      name: 'Acme',
+      url: 'https://www.example.com/organization/acme123',
+    },
+  ]);
+});

--- a/src/utils/buildArticle.ts
+++ b/src/utils/buildArticle.ts
@@ -1,0 +1,29 @@
+import { Author, isAuthor } from '../types';
+
+export const formatAuthorName = (authorName: string | string[]) =>
+  Array.isArray(authorName)
+    ? authorName.map(name => ({ '@type': 'Person', name: name }))
+    : { '@type': 'Person', name: authorName };
+
+export const buildAuthor = (author: Author | Author[] | string | string[]) => {
+  return Array.isArray(author)
+    ? author.map(author =>
+        isAuthor(author)
+          ? formatSingleAuthor(author)
+          : formatAuthorName(author),
+      )
+    : isAuthor(author)
+    ? formatSingleAuthor(author)
+    : formatAuthorName(author);
+};
+
+export const formatAuthors = (author: Author[]) =>
+  author.map(formatSingleAuthor);
+
+export const formatSingleAuthor = (author: Author) => {
+  return {
+    '@type': author.type,
+    name: author.name,
+    url: author.url,
+  };
+};

--- a/src/utils/buildArticle.ts
+++ b/src/utils/buildArticle.ts
@@ -5,7 +5,12 @@ export const formatAuthorName = (authorName: string | string[]) =>
     ? authorName.map(name => ({ '@type': 'Person', name: name }))
     : { '@type': 'Person', name: authorName };
 
-export const buildAuthor = (author: Author | Author[] | string | string[]) => {
+export const buildAuthor = (
+  author: Author | Author[] | string | string[] | undefined | null,
+) => {
+  if (author === undefined || author === null) {
+    return '';
+  }
   return Array.isArray(author)
     ? author.map(author =>
         isAuthor(author)


### PR DESCRIPTION
## Description of Change(s):
Create a new attribute: author (optional) and closes #848
It is backward compatible with existing authorName property and provide an easy way to add url to authors like [google suggest](https://developers.google.com/search/docs/advanced/structured-data/article#non-amp-sd).