### PR TITLE
fix(NextSeo): og:title and og:description are not overridden #544

### DIFF
--- a/cypress/e2e/seo.spec.js
+++ b/cypress/e2e/seo.spec.js
@@ -285,6 +285,27 @@ describe('SEO Meta', () => {
       });
   });
 
+  it('SEO overrides title without openGraph prop correctly', () => {
+    cy.visit('http://localhost:3000/overridden/titleWithoutOpenGraph');
+    cy.get('h1').should('contain', 'Overridden Title Seo');
+    cy.get('head title').should('contain', 'Title C | Next SEO');
+    cy.get('head meta[name="description"]').should(
+      'have.attr',
+      'content',
+      'Description C',
+    );
+    cy.get('head meta[property="og:title"]').should(
+      'have.attr',
+      'content',
+      'Title C | Next SEO',
+    );
+    cy.get('head meta[property="og:description"]').should(
+      'have.attr',
+      'content',
+      'Description C',
+    );
+  });
+
   it('Profile SEO loads correctly', () => {
     cy.visit('http://localhost:3000/profile');
     cy.get('h1').should('contain', 'Profile Page SEO');

--- a/e2e/next-env.d.ts
+++ b/e2e/next-env.d.ts
@@ -1,2 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/e2e/pages/overridden/titleWithoutOpenGraph.tsx
+++ b/e2e/pages/overridden/titleWithoutOpenGraph.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { NextSeo } from '../../..';
+import Links from '../../components/links';
+
+const OverriddenTitle = () => (
+  <>
+    <NextSeo title="Title C" description="Description C" />
+    <h1>Overridden Title Seo</h1>
+    <Links />
+  </>
+);
+
+export default OverriddenTitle;

--- a/src/meta/__tests__/__snapshots__/buildTags.spec.tsx.snap
+++ b/src/meta/__tests__/__snapshots__/buildTags.spec.tsx.snap
@@ -30,6 +30,14 @@ exports[`Article SEO renders correctly 1`] = `
     name="twitter:creator"
   />
   <meta
+    content="Open Graph Article Title"
+    property="og:title"
+  />
+  <meta
+    content="Description of open graph article"
+    property="og:description"
+  />
+  <meta
     content="https://www.example.com/articles/article-title"
     property="og:url"
   />
@@ -68,14 +76,6 @@ exports[`Article SEO renders correctly 1`] = `
   <meta
     content="Tag B"
     property="article:tag"
-  />
-  <meta
-    content="Open Graph Article Title"
-    property="og:title"
-  />
-  <meta
-    content="Description of open graph article"
-    property="og:description"
   />
   <meta
     content="https://www.test.ie/og-image-article-title-01.jpg"
@@ -146,6 +146,14 @@ exports[`Book SEO renders correctly 1`] = `
     name="twitter:creator"
   />
   <meta
+    content="Open Graph Book Title"
+    property="og:title"
+  />
+  <meta
+    content="Description of open graph book"
+    property="og:description"
+  />
+  <meta
     content="https://www.example.com/books/book-title"
     property="og:url"
   />
@@ -176,14 +184,6 @@ exports[`Book SEO renders correctly 1`] = `
   <meta
     content="Tag B"
     property="book:tag"
-  />
-  <meta
-    content="Open Graph Book Title"
-    property="og:title"
-  />
-  <meta
-    content="Description of open graph book"
-    property="og:description"
   />
   <meta
     content="https://www.test.ie/og-image-book-title-01.jpg"
@@ -254,6 +254,14 @@ exports[`Profile SEO renders correctly 1`] = `
     name="twitter:creator"
   />
   <meta
+    content="Open Graph Profile Title"
+    property="og:title"
+  />
+  <meta
+    content="Description of open graph profile"
+    property="og:description"
+  />
+  <meta
     content="https://www.example.com/@firstlast123"
     property="og:url"
   />
@@ -276,14 +284,6 @@ exports[`Profile SEO renders correctly 1`] = `
   <meta
     content="male"
     property="profile:gender"
-  />
-  <meta
-    content="Open Graph Profile Title"
-    property="og:title"
-  />
-  <meta
-    content="Description of open graph profile"
-    property="og:description"
   />
   <meta
     content="https://www.test.ie/og-image-firstlast123-01.jpg"
@@ -354,6 +354,14 @@ exports[`Video SEO renders correctly 1`] = `
     name="twitter:creator"
   />
   <meta
+    content="Open Graph Video Title"
+    property="og:title"
+  />
+  <meta
+    content="Description of open graph video"
+    property="og:description"
+  />
+  <meta
     content="https://www.example.com/videos/video-title"
     property="og:url"
   />
@@ -408,14 +416,6 @@ exports[`Video SEO renders correctly 1`] = `
   <meta
     content="Tag B"
     property="video:tag"
-  />
-  <meta
-    content="Open Graph Video Title"
-    property="og:title"
-  />
-  <meta
-    content="Description of open graph video"
-    property="og:description"
   />
   <meta
     content="https://www.test.ie/og-image-video-title-01.jpg"
@@ -505,20 +505,20 @@ exports[`renders correctly 1`] = `
     property="fb:app_id"
   />
   <meta
-    content="https://www.url.ie"
-    property="og:url"
-  />
-  <meta
-    content="website"
-    property="og:type"
-  />
-  <meta
     content="Open graph title"
     property="og:title"
   />
   <meta
     content="This is testing og:description."
     property="og:description"
+  />
+  <meta
+    content="https://www.url.ie"
+    property="og:url"
+  />
+  <meta
+    content="website"
+    property="og:type"
   />
   <meta
     content="https://www.test.ie/image-01.jpg"

--- a/src/meta/buildTags.tsx
+++ b/src/meta/buildTags.tsx
@@ -185,6 +185,26 @@ const buildTags = (config: BuildTagsParams) => {
     }
   }
 
+  if (config.openGraph?.title || config.title) {
+    tagsToRender.push(
+      <meta
+        key="og:title"
+        property="og:title"
+        content={config.openGraph?.title || updatedTitle}
+      />,
+    );
+  }
+
+  if (config.openGraph?.description || config.description) {
+    tagsToRender.push(
+      <meta
+        key="og:description"
+        property="og:description"
+        content={config.openGraph?.description || config.description}
+      />,
+    );
+  }
+
   if (config.openGraph) {
     if (config.openGraph.url || config.canonical) {
       tagsToRender.push(
@@ -466,26 +486,6 @@ const buildTags = (config: BuildTagsParams) => {
           );
         }
       }
-    }
-
-    if (config.openGraph.title || config.title) {
-      tagsToRender.push(
-        <meta
-          key="og:title"
-          property="og:title"
-          content={config.openGraph.title || updatedTitle}
-        />,
-      );
-    }
-
-    if (config.openGraph.description || config.description) {
-      tagsToRender.push(
-        <meta
-          key="og:description"
-          property="og:description"
-          content={config.openGraph.description || config.description}
-        />,
-      );
     }
 
     // images


### PR DESCRIPTION
## Description of Change(s):

Fixes https://github.com/garmeeh/next-seo/issues/544 , `og:title` & `og:description` can now be overridden by `<NextSeo>` when `openGraph` prop exists on `<DefaultSeo>`

Some things to help get a PR reviewed and merged faster:

- **Have you updated the documentation to go with your changes?** 
   Bug fix, this change doesn't require documentation update
- **Have you written or updated unit tests?**
   Updated snapshots
- **Have you written an integration test in the test app supplied?**
   Added a new integration test

The above are generally required on all PR's.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
