### PR TITLE
Fix trailing comma in videGameJsonLd

### DIFF
--- a/src/jsonld/videoGame.tsx
+++ b/src/jsonld/videoGame.tsx
@@ -79,7 +79,6 @@ const VideoGameJsonLd: FC<VideoGameJsonLdProps> = ({
   const jslonld = `{
     "@context": "https://schema.org/",
     "@type": "VideoGame",
-    "name": "${name}",
     ${description ? `"description": "${description}",` : ''}
     ${aggregateRating ? buildAggregateRating(aggregateRating) : ''}
     ${datePublished ? `"datePublished": "${datePublished}",` : ''}
@@ -208,9 +207,10 @@ const VideoGameJsonLd: FC<VideoGameJsonLdProps> = ({
             Array.isArray(offers)
               ? `[${offers.map(offer => `${buildOffers(offer)}`)}]`
               : buildOffers(offers)
-          }`
+          },`
         : ''
     }
+    "name": "${name}"
   }`;
 
   return (


### PR DESCRIPTION
## Description of Change(s):
Move a mandatory field to the end and let it terminate (no comma) the tag.

Validators are currently erroring, if you omit the offers type, which is optional.

See https://validator.schema.org/#url=https%3A%2F%2Fflathub.vercel.app%2Fapps%2Fdetails%2Fnet.sourceforge.btanks for an example of a failing validator

---

Some things to help get a PR reviewed and merged faster:

- Have you updated the documentation to go with your changes?
Shouldn't be needed, as it's a fix
- Have you written or updated unit tests?
No
- Have you written an integration test in the test app supplied?
No
