### PR TITLE
Omit invalid props of DefaultSeo Components

### DIFF
--- a/cypress/e2e/seo.dangerously.spec.js
+++ b/cypress/e2e/seo.dangerously.spec.js
@@ -67,4 +67,20 @@ describe('SEO Meta Dangerously', () => {
       'noindex,nofollow',
     );
   });
+
+  it('SEO nofollow and noindex but not valid props, it is ignored', () => {
+    cy.visit(
+      'http://localhost:3000/dangerously/nofollow-and-noindex-invalid-props',
+    );
+    cy.get('head meta[name="robots"]').should(
+      'have.attr',
+      'content',
+      'index,follow',
+    );
+    cy.get('head meta[name="googlebot"]').should(
+      'have.attr',
+      'content',
+      'index,follow',
+    );
+  });
 });

--- a/e2e/components/links.tsx
+++ b/e2e/components/links.tsx
@@ -108,6 +108,11 @@ const Links = () => (
           <a>Dangerously AllPagesToNoFollow and AllPagesToNoIndex</a>
         </Link>
       </li>
+      <li>
+        <Link href="/dangerously/nofollow-and-noindex-invalid-props">
+          <a>Dangerously nofollow and noindex But not valid props</a>
+        </Link>
+      </li>
     </ul>
   </>
 );

--- a/e2e/pages/dangerously/nofollow-and-noindex-invalid-props.tsx
+++ b/e2e/pages/dangerously/nofollow-and-noindex-invalid-props.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { DefaultSeo, DefaultSeoProps } from '../../../';
+import Links from '../../components/links';
+
+const DangerouslyNoFollowAndNoIndexThroughUnsupportedProps = () => {
+  const props = {
+    noindex: true,
+    nofollow: true,
+  } as DefaultSeoProps;
+
+  return (
+    <>
+      <DefaultSeo
+        title="DangerouslyNoFollowAndNoIndexThroughUnsupportedProps"
+        {...props}
+      />
+      <h1>DangerouslyNoFollowAndNoIndexThroughUnsupportedProps</h1>
+      <Links />
+    </>
+  );
+};
+
+export default DangerouslyNoFollowAndNoIndexThroughUnsupportedProps;

--- a/src/types.ts
+++ b/src/types.ts
@@ -264,7 +264,11 @@ export interface NextSeoProps {
   disableGooglebot?: boolean;
 }
 
-export interface DefaultSeoProps extends NextSeoProps {
+export interface DefaultSeoProps
+  extends Omit<
+    NextSeoProps,
+    'noindex' | 'nofollow' | 'disableGooglebot' | 'robotsProps'
+  > {
   dangerouslyDisableGooglebot?: boolean;
   dangerouslySetAllPagesToNoIndex?: boolean;
   dangerouslySetAllPagesToNoFollow?: boolean;


### PR DESCRIPTION
## Description of Change(s):
These four properties are defined in DefaultSEO props but not used internally. Remove it from type as it can confuse users

Fix #897 

---

Some things to help get a PR reviewed and merged faster:

- Have you updated the documentation to go with your changes?
- Have you written or updated unit tests?
- Have you written an integration test in the test app supplied?

The above are generally required on all PR's.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
