### PR TITLE
Add more properties to JsonLd Event and allow VirtualLocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2065,6 +2065,7 @@ const Page = () => (
           seller: {
             name: 'John Doe',
           },
+          validFrom: '2020-11-01T00:00:00.000Z',
         },
         {
           price: '139.99',
@@ -2076,6 +2077,7 @@ const Page = () => (
           seller: {
             name: 'John Doe Sr.',
           },
+          validFrom: '2020-08-05T00:00:00.000Z',
         },
       ]}
       performers={[
@@ -2086,6 +2088,13 @@ const Page = () => (
           name: 'Kira and Morrison',
         },
       ]}
+      organizer={{
+        type: 'Organization',
+        name: 'Unnamed organization',
+        url: 'https://www.unnamed.com',
+      }}
+      eventStatus="EventScheduled"
+      eventAttendanceMode="OfflineEventAttendanceMode"
     />
   </>
 );
@@ -2095,24 +2104,52 @@ export default Page;
 
 **Required properties**
 
-| Property    | Info                                               |
-| ----------- | -------------------------------------------------- |
-| `name`      | The name of the event                              |
-| `startDate` | The start date time of the event in iso8601 format |
-| `endDate`   | The end date time of the event in iso8601 format   |
-| `location`  | Place type with a nested Address type              |
+| Property    | Info                                                       |
+| ----------- | ---------------------------------------------------------- |
+| `name`      | The name of the event                                      |
+| `startDate` | The start date time of the event in iso8601 format         |
+| `endDate`   | The end date time of the event in iso8601 format           |
+| `location`  | Location of the event, can be `Place` or `VirtualLocation` |
+
+**`Place` type**
+Requires `address` property and `name`.
+
+**`VirtualLocation` type**
+Requires `url` property, doesn't require `name`.
 
 **Supported properties**
 
-| Property          | Info                                                                                                                                                            |
-| ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `description`     | Description of the event                                                                                                                                        |
-| `location.sameAs` | Description of the event location                                                                                                                               |
-| `images`          | An image or images of the event.                                                                                                                                |
-| `url`             | The fully-qualified URL of the event.                                                                                                                           |
-| `offers`          | An offer to transfer some rights to an item or to provide a service. You can provide this as a single object, or an array of objects with the properties below. |
-| `performers`      | All artists that perform at this event. You can provide this as a single object, or an array of objects with the properties below.                              |
-| `performers.name` | The name of the performer                                                                                                                                       |
+| Property              | Info                                                                                                                                                            |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `description`         | Description of the event                                                                                                                                        |
+| `location.name`       | Name of the location                                                                                                                                            |
+| `location.sameAs`     | URL of a reference web page that identifies location                                                                                                            |
+| `images`              | An image or images of the event.                                                                                                                                |
+| `url`                 | The fully-qualified URL of the event.                                                                                                                           |
+| `offers`              | An offer to transfer some rights to an item or to provide a service. You can provide this as a single object, or an array of objects with the properties below. |
+| `performers`          | All artists that perform at this event. You can provide this as a single object, or an array of objects with the properties below.                              |
+| `performers.name`     | The name of the performer                                                                                                                                       |
+| `performers.type`     | Either `Person` or `PerformingGroup`                                                                                                                            |
+| `organizer`           | The organizer of the event                                                                                                                                      |
+| `organizer.type`      | Either `Organization` or `Person`                                                                                                                               |
+| `organizer.name`      | Name of the organizer of the event                                                                                                                              |
+| `organizer.url`       | URL of the organizer of the event                                                                                                                               |
+| `eventStatus`         | Status of the event, type `EventStatus`                                                                                                                         |
+| `eventAttendanceMode` | Attendance mode of the event, type `EventAttendanceMode`                                                                                                        |
+
+**`EventStatus` type**
+
+- 'EventCancelled'
+- 'EventMovedOnline'
+- 'EventPostponed'
+- 'EventRescheduled'
+- 'EventScheduled'
+
+**`EventAttendanceMode` type**
+
+- 'MixedEventAttendanceMode'
+- 'OfflineEventAttendanceMode'
+- 'OnlineEventAttendanceMode'
 
 **`offers` Required properties**
 
@@ -2131,6 +2168,7 @@ export default Page;
 | `offers.url`             | URL of the item                                                                     |
 | `offers.seller`          | The person who is selling this item                                                 |
 | `offers.seller.name`     | The name of the person                                                              |
+| `offers.validFrom`       | Since when the price of the offer is valid                                          |
 
 The property `aggregateOffer` is also available:
 (It is ignored if `offers` is set)

--- a/cypress/e2e/event.spec.js
+++ b/cypress/e2e/event.spec.js
@@ -48,6 +48,7 @@ describe('Event JSON-LD', () => {
               '@type': 'Organization',
               name: 'John Doe',
             },
+            validFrom: '2020-11-01T00:00:00.000Z',
           },
           {
             '@type': 'Offer',
@@ -60,6 +61,7 @@ describe('Event JSON-LD', () => {
               '@type': 'Organization',
               name: 'John Doe sr.',
             },
+            validFrom: '2020-08-05T00:00:00.000Z',
           },
         ],
         performer: [
@@ -72,6 +74,13 @@ describe('Event JSON-LD', () => {
             name: 'Kira and Morrison',
           },
         ],
+        organizer: {
+          '@type': 'Organization',
+          name: 'Unnamed organization',
+          url: 'https://www.unnamed.com',
+        },
+        eventStatus: 'https://schema.org/EventScheduled',
+        eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
       });
     });
   });

--- a/cypress/e2e/virtualEvent.spec.js
+++ b/cypress/e2e/virtualEvent.spec.js
@@ -1,0 +1,52 @@
+import { assertSchema } from '@cypress/schema-tools';
+import schemas from '../schemas';
+
+describe('Event JSON-LD', () => {
+  it('matches schema', () => {
+    cy.visit('http://localhost:3000/jsonld/virtualEvent');
+    cy.get('head script[type="application/ld+json"]').then(tags => {
+      const jsonLD = JSON.parse(tags[0].innerHTML);
+      assertSchema(schemas)('Event', '1.0.0')(jsonLD);
+    });
+  });
+
+  it('renders with all props', () => {
+    cy.visit('http://localhost:3000/jsonld/virtualEvent');
+    cy.get('head script[type="application/ld+json"]').then(tags => {
+      const jsonLD = JSON.parse(tags[0].innerHTML);
+      expect(jsonLD).to.deep.equal({
+        '@context': 'https://schema.org',
+        '@type': 'Event',
+        name: 'Virtual Event',
+        startDate: '2020-01-23T00:00:00.000Z',
+        endDate: '2020-01-24T00:00:00.000Z',
+        url: 'https://example.com/virtual-event',
+        description: 'Virtual event @ A Livestream Platform',
+        location: {
+          name: 'A Livestream Platform',
+          sameAs: 'https://example.com/another-virtual-event',
+          url: 'https://example.com/virtual-event/watch',
+          '@type': 'VirtualLocation',
+        },
+        image: ['https://example.com/photos/photo.jpg'],
+        performer: [
+          {
+            name: 'Adele',
+            '@type': 'PerformingGroup',
+          },
+          {
+            name: 'Kira and Morrison',
+            '@type': 'PerformingGroup',
+          },
+        ],
+        organizer: {
+          '@type': 'Organization',
+          name: 'Unnamed organization',
+          url: 'https://www.unnamed.com',
+        },
+        eventStatus: 'https://schema.org/EventScheduled',
+        eventAttendanceMode: 'https://schema.org/OnlineEventAttendanceMode',
+      });
+    });
+  });
+});

--- a/e2e/pages/jsonld/event.tsx
+++ b/e2e/pages/jsonld/event.tsx
@@ -33,6 +33,7 @@ function Event() {
             seller: {
               name: 'John Doe',
             },
+            validFrom: '2020-11-01T00:00:00.000Z',
           },
           {
             price: '139.99',
@@ -43,6 +44,7 @@ function Event() {
             seller: {
               name: 'John Doe sr.',
             },
+            validFrom: '2020-08-05T00:00:00.000Z',
           },
         ]}
         aggregateOffer={{
@@ -59,6 +61,13 @@ function Event() {
             name: 'Kira and Morrison',
           },
         ]}
+        organizer={{
+          type: 'Organization',
+          name: 'Unnamed organization',
+          url: 'https://www.unnamed.com',
+        }}
+        eventStatus="EventScheduled"
+        eventAttendanceMode="OfflineEventAttendanceMode"
       />
     </>
   );

--- a/e2e/pages/jsonld/virtualEvent.tsx
+++ b/e2e/pages/jsonld/virtualEvent.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { EventJsonLd } from '../../..';
+
+function VirtualEvent() {
+  return (
+    <>
+      <h1>VirtualEvent</h1>
+      <EventJsonLd
+        name="Virtual Event"
+        startDate="2020-01-23T00:00:00.000Z"
+        endDate="2020-01-24T00:00:00.000Z"
+        location={{
+          name: 'A Livestream Platform',
+          sameAs: 'https://example.com/another-virtual-event',
+          url: 'https://example.com/virtual-event/watch',
+        }}
+        url="https://example.com/virtual-event"
+        images={['https://example.com/photos/photo.jpg']}
+        description="Virtual event @ A Livestream Platform"
+        performers={[
+          {
+            name: 'Adele',
+          },
+          {
+            name: 'Kira and Morrison',
+          },
+        ]}
+        organizer={{
+          type: 'Organization',
+          name: 'Unnamed organization',
+          url: 'https://www.unnamed.com',
+        }}
+        eventStatus="EventScheduled"
+        eventAttendanceMode="OnlineEventAttendanceMode"
+      />
+    </>
+  );
+}
+
+export default VirtualEvent;

--- a/src/jsonld/event.tsx
+++ b/src/jsonld/event.tsx
@@ -1,11 +1,20 @@
 import React from 'react';
 
 import { JsonLd, JsonLdProps } from './jsonld';
-import type { Location, AggregateOffer, Offers, Performer } from 'src/types';
+import type {
+  Location,
+  AggregateOffer,
+  Offers,
+  Performer,
+  Organizer,
+  EventStatus,
+  EventAttendanceMode,
+} from 'src/types';
 import { setLocation } from 'src/utils/schema/setLocation';
 import { setPerformer } from 'src/utils/schema/setPerformer';
 import { setOffers } from 'src/utils/schema/setOffers';
 import { setAggregateOffer } from 'src/utils/schema/setAggregateOffer';
+import { setOrganizer } from 'src/utils/schema/setOrganizer';
 
 export interface EventJsonLdProps extends JsonLdProps {
   name: string;
@@ -18,6 +27,9 @@ export interface EventJsonLdProps extends JsonLdProps {
   offers?: Offers | Offers[];
   aggregateOffer?: AggregateOffer;
   performers?: Performer | Performer[];
+  organizer?: Organizer;
+  eventStatus?: EventStatus;
+  eventAttendanceMode?: EventAttendanceMode;
 }
 
 function EventJsonLd({
@@ -28,6 +40,9 @@ function EventJsonLd({
   offers,
   aggregateOffer,
   performers,
+  organizer,
+  eventStatus,
+  eventAttendanceMode,
   ...rest
 }: EventJsonLdProps) {
   const data = {
@@ -38,7 +53,13 @@ function EventJsonLd({
     performer: Array.isArray(performers)
       ? performers.map(setPerformer)
       : setPerformer(performers),
+    organizer: Array.isArray(organizer)
+      ? organizer.map(setOrganizer)
+      : setOrganizer(organizer),
+    eventStatus: `https://schema.org/${eventStatus}`,
+    eventAttendanceMode: `https://schema.org/${eventAttendanceMode}`,
   };
+
   return (
     <JsonLd type={type} keyOverride={keyOverride} {...data} scriptKey="Event" />
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -67,14 +67,41 @@ export interface Instruction {
   image?: string;
 }
 export interface Performer {
+  type?: 'Person' | 'PerformingGroup';
   name: string;
 }
-
-export interface Location {
+export interface Place {
   name: string;
   address: Address;
   sameAs?: string;
 }
+
+export interface VirtualLocation {
+  name?: string;
+  sameAs?: string;
+  url: string;
+}
+
+export type Location = Place | VirtualLocation;
+
+export type EventStatus =
+  | 'EventCancelled'
+  | 'EventMovedOnline'
+  | 'EventPostponed'
+  | 'EventRescheduled'
+  | 'EventScheduled';
+
+export type EventAttendanceMode =
+  | 'MixedEventAttendanceMode'
+  | 'OfflineEventAttendanceMode'
+  | 'OnlineEventAttendanceMode';
+
+export interface Organizer {
+  type: 'Person' | 'Organization';
+  name: string;
+  url: string;
+}
+
 export interface ContactPoint {
   contactType: string;
   telephone: string;
@@ -174,6 +201,7 @@ export type Offers = {
   seller: {
     name: string;
   };
+  validFrom?: string;
 };
 
 export type AggregateOffer = {

--- a/src/utils/schema/setLocation.ts
+++ b/src/utils/schema/setLocation.ts
@@ -1,14 +1,29 @@
-import { Location } from 'src/types';
+import { Location, Place, VirtualLocation } from 'src/types';
 import { setAddress } from './setAddress';
 
 export function setLocation(location: Location) {
-  if (location) {
-    return {
-      ...location,
-      '@type': 'Place',
-      address: setAddress(location.address),
-    };
+  if (!location) {
+    return undefined;
   }
 
-  return undefined;
+  if ('url' in location) {
+    return setVirtualLocation(location);
+  } else {
+    return setPlace(location);
+  }
+}
+
+function setVirtualLocation(location: VirtualLocation) {
+  return {
+    ...location,
+    '@type': 'VirtualLocation',
+  };
+}
+
+function setPlace(location: Place) {
+  return {
+    ...location,
+    address: setAddress(location.address),
+    '@type': 'Place',
+  };
 }

--- a/src/utils/schema/setOrganizer.ts
+++ b/src/utils/schema/setOrganizer.ts
@@ -1,0 +1,13 @@
+import { Organizer } from 'src/types';
+
+export function setOrganizer(organizer?: Organizer) {
+  if (organizer) {
+    const { type, ...restOrganizer } = organizer;
+    return {
+      ...restOrganizer,
+      '@type': type || 'Person',
+    };
+  }
+
+  return undefined;
+}

--- a/src/utils/schema/setPerformer.ts
+++ b/src/utils/schema/setPerformer.ts
@@ -2,9 +2,10 @@ import { Performer } from 'src/types';
 
 export function setPerformer(performer?: Performer) {
   if (performer) {
+    const { type, ...restPerformer } = performer;
     return {
-      ...performer,
-      '@type': 'PerformingGroup',
+      ...restPerformer,
+      '@type': type || 'PerformingGroup',
     };
   }
 


### PR DESCRIPTION
Hey maintainers! First of all, thanks for this awesome plugin. This is my first time contributing, I needed some more properties and wanted to keep on using this plugin rather than write them out by hand on a script tag. I tried to follow all the guidelines, if there's anything else you need me to do to get this merged I'll follow!

## Description of Change(s):

Extended `EventJsonLd` to accept more properties:
- Location can now be a `VirtualLocation` as well as a `Place`
- Added `organizer`, `eventStatus` and `eventAttendanceMode`
- Performers can be both `Person` or `PerformingGroup`

Updated documentation and tests to fit my changes.