### PR TITLE
More notes on Twitter props

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@ export default Page;
 
 **A note on Twitter Tags**
 
+Props `cardType`, `site`, `handle` are equivalent to `twitter:card`, `twitter:site`, `twitter:creator`. Documentation can be founded [here](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary).
+
 Twitter will read the `og:title`, `og:image` and `og:description` tags for their card. `next-seo` omits `twitter:title`, `twitter:image` and `twitter:description` to avoid duplication.
 
 Some tools may report this an error. See [Issue #14](https://github.com/garmeeh/next-seo/issues/14)


### PR DESCRIPTION
I search for document about Twitter SEO with Twitter props name (i.e: "twitter:site", "twitter card site seo") but got very misleading result.

Beside my change in this `README.md`, I suggest change prop `handler` name --> `creator`.

## Description of Change(s):

Props `cardType`, `site`, `handle` are equivalent to `twitter:card`, `twitter:site`, `twitter:creator`. Documentation can be founded [here](https://developer.twitter.com/en/docs/twitter-for-websites/cards/overview/summary).

---

Some things to help get a PR reviewed and merged faster:

- Have you updated the documentation to go with your changes?
- Have you written or updated unit tests?
- Have you written an integration test in the test app supplied?

The above are generally required on all PR's.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
