### PR TITLE
Change brand type to Brand

### DIFF
--- a/src/jsonld/product.tsx
+++ b/src/jsonld/product.tsx
@@ -39,7 +39,7 @@ export interface ProductJsonLdProps {
 
 const buildBrand = (brand: string) => `
   "brand": {
-      "@type": "Thing",
+      "@type": "Brand",
       "name": "${brand}"
     },
 `;


### PR DESCRIPTION
Google gives error on type Thing. Should be Brand. See documentation of google https://developers.google.com/search/docs/advanced/structured-data/product.

## Description of Change(s):
- Changed type of brand object from Thing to Brand