### PR TITLE
Fix typo - yarn e2e:dev instead of yarn e2eL:dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ yarn build
 You can now run the Next.js app in dev mode:
 
 ```
-yarn e2eL:dev
+yarn e2e:dev
 ```
 
 Or do a production build:


### PR DESCRIPTION
[e2e:dev](https://github.com/garmeeh/next-seo/blob/4776325a473df40207efef99d32bcfa6243766ee/package.json#L36) is defined under the scripts option in the `package.json` file but there is no ~e2eL:dev~ listed.
Most likely a typo or a missed script inclusion.