### PR TITLE
revert missing props for the social JSON LD

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -61,6 +61,6 @@ export {
 export { default as BrandJsonLd, BrandJsonLdProps } from './jsonld/brand';
 export { default as ArticleJsonLd, ArticleJsonLdProps } from './jsonld/article';
 export { default as WebPageJsonLd, WebPageJsonLdProps } from './jsonld/webPage';
-export { default as SocialProfileJsonLd } from './jsonld/socialProfile';
+export { default as SocialProfileJsonLd, SocialProfileJsonLdProps } from './jsonld/socialProfile';
 
 export { DefaultSeoProps, NextSeoProps } from './types';


### PR DESCRIPTION
## Description of Change(s):

It seems the props type for `SocialProfileJsonLd` (i.e. `SocialProfileJsonLdProps`) has been accidentally removed. This PR reverts that change.
