### PR TITLE
#932 Update Babel config to include polyfill for older browsers

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   presets: [
-    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-env', { targets: '> 0.25%, not dead' }],
     '@babel/preset-react',
     '@babel/preset-typescript',
   ],


### PR DESCRIPTION
Relates: #932

## Summary:

Current Babel config target is too strict, it doesn't include `?.` operator polyfill. As a result, older browsers fail to compile source code and throw Syntax errors.
This PR updates Babel targets to be less strict and include polyfills for older browsers.

New `targets` config is the default Babel recommendation `> 0.25%, not dead`,
and is taken directly from https://babeljs.io/docs/en/babel-preset-env#browserslist-integration