### PR TITLE
Chore: Convert alias path imports to relative imports

### DIFF
--- a/src/jsonld/article.tsx
+++ b/src/jsonld/article.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { JsonLd, JsonLdProps } from './jsonld';
-import { setAuthor } from 'src/utils/schema/setAuthor';
-import { setPublisher } from 'src/utils/schema/setPublisher';
+import { setAuthor } from '../utils/schema/setAuthor';
+import { setPublisher } from '../utils/schema/setPublisher';
 
 export interface ArticleJsonLdProps extends JsonLdProps {
   type?: 'Article' | 'Blog' | 'NewsArticle';

--- a/src/jsonld/brand.tsx
+++ b/src/jsonld/brand.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import type { AggregateRating } from 'src/types';
-import { setAggregateRating } from 'src/utils/schema/setAggregateRating';
+import type { AggregateRating } from '../types';
+import { setAggregateRating } from '../utils/schema/setAggregateRating';
 
 import { JsonLd, JsonLdProps } from './jsonld';
 

--- a/src/jsonld/breadcrumb.tsx
+++ b/src/jsonld/breadcrumb.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import type { ItemListElements } from 'src/types';
-import { setItemListElements } from 'src/utils/schema/setItemListElements';
+import type { ItemListElements } from '../types';
+import { setItemListElements } from '../utils/schema/setItemListElements';
 
 import { JsonLd, JsonLdProps } from './jsonld';
 

--- a/src/jsonld/carousel.tsx
+++ b/src/jsonld/carousel.tsx
@@ -2,14 +2,14 @@ import React from 'react';
 
 import { JsonLd, JsonLdProps } from './jsonld';
 
-import type { CourseJsonLdProps, RecipeJsonLdProps } from 'src/index';
-import type { Review, AggregateRating } from 'src/types';
-import { setReviews } from 'src/utils/schema/setReviews';
-import { setAuthor } from 'src/utils/schema/setAuthor';
-import { setNutrition } from 'src/utils/schema/setNutrition';
-import { setAggregateRating } from 'src/utils/schema/setAggregateRating';
-import { setVideo } from 'src/utils/schema/setVideo';
-import { setInstruction } from 'src/utils/schema/setInstruction';
+import type { CourseJsonLdProps, RecipeJsonLdProps } from '../index';
+import type { Review, AggregateRating } from '../types';
+import { setReviews } from '../utils/schema/setReviews';
+import { setAuthor } from '../utils/schema/setAuthor';
+import { setNutrition } from '../utils/schema/setNutrition';
+import { setAggregateRating } from '../utils/schema/setAggregateRating';
+import { setVideo } from '../utils/schema/setVideo';
+import { setInstruction } from '../utils/schema/setInstruction';
 
 type Director = {
   name: string;

--- a/src/jsonld/collectionPage.tsx
+++ b/src/jsonld/collectionPage.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { JsonLd, JsonLdProps } from './jsonld';
-import type { CreativeWork } from 'src/types';
-import { setCreativeWork } from 'src/utils/schema/setCreativeWork';
+import type { CreativeWork } from '../types';
+import { setCreativeWork } from '../utils/schema/setCreativeWork';
 
 export interface CollectionPageJsonLdProps extends JsonLdProps {
   name: string;

--- a/src/jsonld/corporateContact.tsx
+++ b/src/jsonld/corporateContact.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import { JsonLd, JsonLdProps } from './jsonld';
-import type { ContactPoint } from 'src/types';
+import type { ContactPoint } from '../types';
 
-import { setContactPoint } from 'src/utils/schema/setContactPoint';
+import { setContactPoint } from '../utils/schema/setContactPoint';
 
 export interface CorporateContactJsonLdProps extends JsonLdProps {
   url: string;

--- a/src/jsonld/course.tsx
+++ b/src/jsonld/course.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import type { Provider } from 'src/types';
-import { setProvider } from 'src/utils/schema/setProvider';
+import type { Provider } from '../types';
+import { setProvider } from '../utils/schema/setProvider';
 
 import { JsonLd, JsonLdProps } from './jsonld';
 

--- a/src/jsonld/event.tsx
+++ b/src/jsonld/event.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 
 import { JsonLd, JsonLdProps } from './jsonld';
-import type { Location, AggregateOffer, Offers, Performer } from 'src/types';
-import { setLocation } from 'src/utils/schema/setLocation';
-import { setPerformer } from 'src/utils/schema/setPerformer';
-import { setOffers } from 'src/utils/schema/setOffers';
-import { setAggregateOffer } from 'src/utils/schema/setAggregateOffer';
+import type { Location, AggregateOffer, Offers, Performer } from '../types';
+import { setLocation } from '../utils/schema/setLocation';
+import { setPerformer } from '../utils/schema/setPerformer';
+import { setOffers } from '../utils/schema/setOffers';
+import { setAggregateOffer } from '../utils/schema/setAggregateOffer';
 
 export interface EventJsonLdProps extends JsonLdProps {
   name: string;

--- a/src/jsonld/faqPage.tsx
+++ b/src/jsonld/faqPage.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import type { Question } from 'src/types';
+import type { Question } from '../types';
 import { JsonLd, JsonLdProps } from './jsonld';
-import { setQuestions } from 'src/utils/schema/setQuestions';
+import { setQuestions } from '../utils/schema/setQuestions';
 
 export interface FAQPageJsonLdProps extends JsonLdProps {
   mainEntity: Question[];

--- a/src/jsonld/jsonld.tsx
+++ b/src/jsonld/jsonld.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Head from 'next/head';
 
-import toJson from 'src/utils/toJson';
+import toJson from '../utils/toJson';
 
 export interface JsonLdProps {
   type?: string;

--- a/src/jsonld/localBusiness.tsx
+++ b/src/jsonld/localBusiness.tsx
@@ -10,15 +10,15 @@ import type {
   GeoCircle,
   OpeningHoursSpecification,
   Offer,
-} from 'src/types';
-import { setAddress } from 'src/utils/schema/setAddress';
-import { setReviews } from 'src/utils/schema/setReviews';
-import { setGeo } from 'src/utils/schema/setGeo';
-import { setAggregateRating } from 'src/utils/schema/setAggregateRating';
-import { setAction } from 'src/utils/schema/setAction';
-import { setGeoCircle } from 'src/utils/schema/setGeoCircle';
-import { setOffer } from 'src/utils/schema/setOffer';
-import { setOpeningHours } from 'src/utils/schema/setOpeningHours';
+} from '../types';
+import { setAddress } from '../utils/schema/setAddress';
+import { setReviews } from '../utils/schema/setReviews';
+import { setGeo } from '../utils/schema/setGeo';
+import { setAggregateRating } from '../utils/schema/setAggregateRating';
+import { setAction } from '../utils/schema/setAction';
+import { setGeoCircle } from '../utils/schema/setGeoCircle';
+import { setOffer } from '../utils/schema/setOffer';
+import { setOpeningHours } from '../utils/schema/setOpeningHours';
 
 export interface LocalBusinessJsonLdProps extends JsonLdProps {
   type: string;

--- a/src/jsonld/newsarticle.tsx
+++ b/src/jsonld/newsarticle.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { setAuthor } from 'src/utils/schema/setAuthor';
-import { setPublisher } from 'src/utils/schema/setPublisher';
+import { setAuthor } from '../utils/schema/setAuthor';
+import { setPublisher } from '../utils/schema/setPublisher';
 
 import { JsonLd, JsonLdProps } from './jsonld';
 

--- a/src/jsonld/organization.tsx
+++ b/src/jsonld/organization.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
-import type { Address, OrganizationCategory, ContactPoint } from 'src/types';
+import type { Address, OrganizationCategory, ContactPoint } from '../types';
 import { JsonLd, JsonLdProps } from './jsonld';
-import { setAddress } from 'src/utils/schema/setAddress';
-import { setContactPoints } from 'src/utils/schema/setContactPoints';
+import { setAddress } from '../utils/schema/setAddress';
+import { setContactPoints } from '../utils/schema/setContactPoints';
 
 export interface OrganizationJsonLdProps extends JsonLdProps {
   type?: OrganizationCategory;

--- a/src/jsonld/product.tsx
+++ b/src/jsonld/product.tsx
@@ -1,19 +1,14 @@
 import React from 'react';
 
 import { JsonLd, JsonLdProps } from './jsonld';
-import type {
-  Review,
-  AggregateRating,
-  AggregateOffer,
-  Offers,
-} from 'src/types';
+import type { Review, AggregateRating, AggregateOffer, Offers } from '../types';
 
-import { setOffers } from 'src/utils/schema/setOffers';
-import { setReviews } from 'src/utils/schema/setReviews';
-import { setAggregateRating } from 'src/utils/schema/setAggregateRating';
-import { setAggregateOffer } from 'src/utils/schema/setAggregateOffer';
-import { setManufacturer } from 'src/utils/schema/setManufacturer';
-import { setBrand } from 'src/utils/schema/setBrand';
+import { setOffers } from '../utils/schema/setOffers';
+import { setReviews } from '../utils/schema/setReviews';
+import { setAggregateRating } from '../utils/schema/setAggregateRating';
+import { setAggregateOffer } from '../utils/schema/setAggregateOffer';
+import { setManufacturer } from '../utils/schema/setManufacturer';
+import { setBrand } from '../utils/schema/setBrand';
 
 export interface ProductJsonLdProps extends JsonLdProps {
   productName: string;

--- a/src/jsonld/profilePage.tsx
+++ b/src/jsonld/profilePage.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
 import { JsonLd, JsonLdProps } from './jsonld';
-import type { ItemListElements } from 'src/types';
-import { setItemListElements } from 'src/utils/schema/setItemListElements';
+import type { ItemListElements } from '../types';
+import { setItemListElements } from '../utils/schema/setItemListElements';
 
 export interface ProfilePageJsonLdProps extends JsonLdProps {
   breadcrumb: string | ItemListElements[];

--- a/src/jsonld/qaPage.tsx
+++ b/src/jsonld/qaPage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import type { Question } from 'src/types';
-import { setAuthor } from 'src/utils/schema/setAuthor';
+import type { Question } from '../types';
+import { setAuthor } from '../utils/schema/setAuthor';
 
 import { JsonLd, JsonLdProps } from './jsonld';
 

--- a/src/jsonld/recipe.tsx
+++ b/src/jsonld/recipe.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
 import { JsonLd, JsonLdProps } from './jsonld';
-import type { Instruction, AggregateRating, Video } from 'src/types';
+import type { Instruction, AggregateRating, Video } from '../types';
 
-import { setAggregateRating } from 'src/utils/schema/setAggregateRating';
-import { setAuthor } from 'src/utils/schema/setAuthor';
-import { setVideo } from 'src/utils/schema/setVideo';
-import { setInstruction } from 'src/utils/schema/setInstruction';
-import { setNutrition } from 'src/utils/schema/setNutrition';
+import { setAggregateRating } from '../utils/schema/setAggregateRating';
+import { setAuthor } from '../utils/schema/setAuthor';
+import { setVideo } from '../utils/schema/setVideo';
+import { setInstruction } from '../utils/schema/setInstruction';
+import { setNutrition } from '../utils/schema/setNutrition';
 
 export interface RecipeJsonLdProps extends JsonLdProps {
   name: string;

--- a/src/jsonld/softwareApp.tsx
+++ b/src/jsonld/softwareApp.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import { JsonLd, JsonLdProps } from './jsonld';
-import type { Review, AggregateRating } from 'src/types';
-import { setAggregateRating } from 'src/utils/schema/setAggregateRating';
-import { setReviews } from 'src/utils/schema/setReviews';
+import type { Review, AggregateRating } from '../types';
+import { setAggregateRating } from '../utils/schema/setAggregateRating';
+import { setReviews } from '../utils/schema/setReviews';
 
 export interface SoftwareAppJsonLdProps extends JsonLdProps {
   name: string;

--- a/src/jsonld/video.tsx
+++ b/src/jsonld/video.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import { Video } from 'src/types';
+import { Video } from '../types';
 
 import { JsonLd, JsonLdProps } from './jsonld';
-import { setVideo } from 'src/utils/schema/setVideo';
+import { setVideo } from '../utils/schema/setVideo';
 
 export interface VideoJsonLdProps extends JsonLdProps, Video {}
 

--- a/src/jsonld/videoGame.tsx
+++ b/src/jsonld/videoGame.tsx
@@ -7,15 +7,15 @@ import type {
   Video,
   Review,
   ApplicationCategory,
-} from 'src/types';
-import { setAggregateRating } from 'src/utils/schema/setAggregateRating';
-import { setAuthor } from 'src/utils/schema/setAuthor';
-import { setImage } from 'src/utils/schema/setImage';
-import { setOffers } from 'src/utils/schema/setOffers';
-import { setProducer } from 'src/utils/schema/setProducer';
-import { setProvider } from 'src/utils/schema/setProvider';
-import { setReviews } from 'src/utils/schema/setReviews';
-import { setVideo } from 'src/utils/schema/setVideo';
+} from '../types';
+import { setAggregateRating } from '../utils/schema/setAggregateRating';
+import { setAuthor } from '../utils/schema/setAuthor';
+import { setImage } from '../utils/schema/setImage';
+import { setOffers } from '../utils/schema/setOffers';
+import { setProducer } from '../utils/schema/setProducer';
+import { setProvider } from '../utils/schema/setProvider';
+import { setReviews } from '../utils/schema/setReviews';
+import { setVideo } from '../utils/schema/setVideo';
 
 import { JsonLd, JsonLdProps } from './jsonld';
 

--- a/src/jsonld/webPage.tsx
+++ b/src/jsonld/webPage.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import type { ReviewedBy } from 'src/types';
+import type { ReviewedBy } from '../types';
 
 import { JsonLd } from './jsonld';
-import { setReviewedBy } from 'src/utils/schema/setReviewedBy';
+import { setReviewedBy } from '../utils/schema/setReviewedBy';
 
 export interface WebPageJsonLdProps {
   keyOverride?: string;

--- a/src/utils/schema/setAction.ts
+++ b/src/utils/schema/setAction.ts
@@ -1,4 +1,4 @@
-import { Action } from 'src/types';
+import { Action } from '../../types';
 
 export function setAction(action?: Action) {
   if (action) {

--- a/src/utils/schema/setAddress.ts
+++ b/src/utils/schema/setAddress.ts
@@ -1,4 +1,4 @@
-import { Address } from 'src/types';
+import { Address } from '../../types';
 
 export function setAddress(address?: Address) {
   if (address) {

--- a/src/utils/schema/setAggregateOffer.ts
+++ b/src/utils/schema/setAggregateOffer.ts
@@ -1,4 +1,4 @@
-import type { AggregateOffer } from 'src/types';
+import type { AggregateOffer } from '../../types';
 import { setOffers } from './setOffers';
 
 export function setAggregateOffer(aggregateOffer?: AggregateOffer) {

--- a/src/utils/schema/setAggregateRating.ts
+++ b/src/utils/schema/setAggregateRating.ts
@@ -1,4 +1,4 @@
-import type { AggregateRating } from 'src/types';
+import type { AggregateRating } from '../../types';
 
 export function setAggregateRating(aggregateRating?: AggregateRating) {
   if (aggregateRating) {

--- a/src/utils/schema/setBroadcastEvent.ts
+++ b/src/utils/schema/setBroadcastEvent.ts
@@ -1,4 +1,4 @@
-import type { BroadcastEvent } from 'src/types';
+import type { BroadcastEvent } from '../../types';
 
 export function setBroadcastEvent(
   publication?: BroadcastEvent | BroadcastEvent[],

--- a/src/utils/schema/setClip.ts
+++ b/src/utils/schema/setClip.ts
@@ -1,4 +1,4 @@
-import { Clip } from 'src/types';
+import { Clip } from '../../types';
 
 export function setClip(clips?: Clip | Clip[]) {
   function mapClip(clip: Clip) {

--- a/src/utils/schema/setContactPoint.ts
+++ b/src/utils/schema/setContactPoint.ts
@@ -1,4 +1,4 @@
-import { ContactPoint } from 'src/types';
+import { ContactPoint } from '../../types';
 
 export function setContactPoint(contactPoint: ContactPoint) {
   if (contactPoint) {

--- a/src/utils/schema/setContactPoints.ts
+++ b/src/utils/schema/setContactPoints.ts
@@ -1,4 +1,4 @@
-import type { ContactPoint } from 'src/types';
+import type { ContactPoint } from '../../types';
 
 export function setContactPoints(contactPoint?: ContactPoint[]) {
   if (contactPoint && contactPoint.length) {

--- a/src/utils/schema/setCreativeWork.ts
+++ b/src/utils/schema/setCreativeWork.ts
@@ -1,4 +1,4 @@
-import { CreativeWork } from 'src/types';
+import { CreativeWork } from '../../types';
 
 export function setCreativeWork(creativeWork: CreativeWork) {
   if (creativeWork) {

--- a/src/utils/schema/setGeo.ts
+++ b/src/utils/schema/setGeo.ts
@@ -1,4 +1,4 @@
-import { Geo } from 'src/types';
+import { Geo } from '../../types';
 
 export function setGeo(geo?: Geo) {
   if (geo) {

--- a/src/utils/schema/setGeoCircle.ts
+++ b/src/utils/schema/setGeoCircle.ts
@@ -1,4 +1,4 @@
-import { GeoCircle } from 'src/types';
+import { GeoCircle } from '../../types';
 
 export function setGeoCircle(geoCircle?: GeoCircle) {
   if (geoCircle) {

--- a/src/utils/schema/setInstruction.ts
+++ b/src/utils/schema/setInstruction.ts
@@ -1,4 +1,4 @@
-import { Instruction } from 'src/types';
+import { Instruction } from '../../types';
 
 export function setInstruction(instruction: Instruction) {
   if (instruction) {

--- a/src/utils/schema/setItemListElements.ts
+++ b/src/utils/schema/setItemListElements.ts
@@ -1,4 +1,4 @@
-import { ItemListElements } from 'src/types';
+import { ItemListElements } from '../../types';
 
 export function setItemListElements(items: ItemListElements[]) {
   if (items && items.length) {

--- a/src/utils/schema/setLocation.ts
+++ b/src/utils/schema/setLocation.ts
@@ -1,4 +1,4 @@
-import { Location } from 'src/types';
+import { Location } from '../../types';
 import { setAddress } from './setAddress';
 
 export function setLocation(location: Location) {

--- a/src/utils/schema/setOffer.ts
+++ b/src/utils/schema/setOffer.ts
@@ -1,4 +1,4 @@
-import type { Offer } from 'src/types';
+import type { Offer } from '../../types';
 
 export function setOffer(offer?: Offer) {
   function setPriceSpecification(

--- a/src/utils/schema/setOffers.ts
+++ b/src/utils/schema/setOffers.ts
@@ -1,4 +1,4 @@
-import { Offers } from 'src/types';
+import { Offers } from '../../types';
 
 export function setOffers(offers?: Offers | Offers[]) {
   function mapOffer({ seller, ...rest }: Offers) {

--- a/src/utils/schema/setOpeningHours.ts
+++ b/src/utils/schema/setOpeningHours.ts
@@ -1,4 +1,4 @@
-import { OpeningHoursSpecification } from 'src/types';
+import { OpeningHoursSpecification } from '../../types';
 
 export function setOpeningHours(openingHours?: OpeningHoursSpecification) {
   if (openingHours) {

--- a/src/utils/schema/setPerformer.ts
+++ b/src/utils/schema/setPerformer.ts
@@ -1,4 +1,4 @@
-import { Performer } from 'src/types';
+import { Performer } from '../../types';
 
 export function setPerformer(performer?: Performer) {
   if (performer) {

--- a/src/utils/schema/setProducer.ts
+++ b/src/utils/schema/setProducer.ts
@@ -1,4 +1,4 @@
-import type { Producer } from 'src/types';
+import type { Producer } from '../../types';
 
 export function setProducer(producer?: Producer) {
   if (producer) {

--- a/src/utils/schema/setProvider.ts
+++ b/src/utils/schema/setProvider.ts
@@ -1,4 +1,4 @@
-import type { Provider } from 'src/types';
+import type { Provider } from '../../types';
 
 export function setProvider(provider: Provider) {
   if (provider) {

--- a/src/utils/schema/setQuestions.ts
+++ b/src/utils/schema/setQuestions.ts
@@ -1,4 +1,4 @@
-import type { Question } from 'src/types';
+import type { Question } from '../../types';
 
 export function setQuestions(questions: Question[]) {
   if (questions && questions.length) {

--- a/src/utils/schema/setReviewRating.ts
+++ b/src/utils/schema/setReviewRating.ts
@@ -1,4 +1,4 @@
-import type { ReviewRating } from 'src/types';
+import type { ReviewRating } from '../../types';
 
 export function setReviewRating(rating?: ReviewRating) {
   if (rating) {

--- a/src/utils/schema/setReviewedBy.ts
+++ b/src/utils/schema/setReviewedBy.ts
@@ -1,4 +1,4 @@
-import type { ReviewedBy } from 'src/types';
+import type { ReviewedBy } from '../../types';
 
 export function setReviewedBy(reviewedBy?: ReviewedBy) {
   if (reviewedBy) {

--- a/src/utils/schema/setReviews.ts
+++ b/src/utils/schema/setReviews.ts
@@ -1,4 +1,4 @@
-import type { Review } from 'src/types';
+import type { Review } from '../../types';
 import { setAuthor } from './setAuthor';
 import { setPublisher } from './setPublisher';
 import { setReviewRating } from './setReviewRating';

--- a/src/utils/schema/setVideo.ts
+++ b/src/utils/schema/setVideo.ts
@@ -1,4 +1,4 @@
-import type { Video } from 'src/types';
+import type { Video } from '../../types';
 
 import { setClip } from './setClip';
 import { setInteractionStatistic } from './setInteractionStatistic';


### PR DESCRIPTION
This fixes the issue with built typescript artifacts throwing "Cannot find module 'src/types' or its corresponding type declarations" errors.
See https://github.com/garmeeh/next-seo/issues/942

## Description of Change(s):
- Replaced all of the aliased `src/*` imports with relative imports.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
