### PR TITLE
disable children property from NextSeo as it is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -501,7 +501,8 @@ languageAlternates={[{
 
 #### Additional Meta Tags
 
-This allows you to add any other meta tags that are not covered in the `config`.
+This allows you to add any other meta tags that are not covered in the `config` and
+should be used instead of `children` prop.
 
 `content` is required. Then either `name`, `property` or `httpEquiv`. (Only one on each)
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -455,6 +455,7 @@ export interface NextSeoProps {
   twitter?: Twitter;
   additionalMetaTags?: ReadonlyArray<MetaTag>;
   additionalLinkTags?: ReadonlyArray<LinkTag>;
+  children?: never;
 }
 
 export interface DefaultSeoProps {


### PR DESCRIPTION
## Description of Change(s):
Children property should be disabled as it is not supported by the NextSeo component. I've also added the note that the `additionalMetaTags` should be used for custom tags. Please let me know if tests are needed for this case.

---

To help get PR's merged faster, the following is required:

[] Updated the documentation
[] Unit/Cypress test covering all cases

Please link to relevant Google Docs or schema.org docs for what you are adding so we can review.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
