### PR TITLE
Add siteName next to site_name to respect camelCase convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Coffee fuels coding ☕️
     - [Book](#book)
     - [Profile](#profile)
 - [JSON-LD](#json-ld)
-  - [JSON-LD Security](#json-ld-security)
-  - [Handling multiple instances](#handling-multiple-instances)
+    - [JSON-LD Security](#json-ld-security)
+    - [Handling multiple instances](#handling-multiple-instances)
   - [Article](#article-1)
   - [Breadcrumb](#breadcrumb)
   - [Blog](#blog)
@@ -162,7 +162,7 @@ const Page = () => (
           { url: 'https://www.example.ie/og-image-03.jpg' },
           { url: 'https://www.example.ie/og-image-04.jpg' },
         ],
-        site_name: 'SiteName',
+        siteName: 'SiteName',
       }}
       twitter={{
         handle: '@handle',
@@ -212,7 +212,7 @@ export default class MyApp extends App {
             type: 'website',
             locale: 'en_IE',
             url: 'https://www.url.ie/',
-            site_name: 'SiteName',
+            siteName: 'SiteName',
           }}
           twitter={{
             handle: '@handle',
@@ -237,7 +237,7 @@ export default {
     type: 'website',
     locale: 'en_IE',
     url: 'https://www.url.ie/',
-    site_name: 'SiteName',
+    siteName: 'SiteName',
   },
   twitter: {
     handle: '@handle',
@@ -291,7 +291,7 @@ From now on all of your pages will have the defaults above applied.
 | `openGraph.images`                 | array                   | An array of images (object) to be used by social media platforms, slack etc as a preview. If multiple supplied you can choose one when sharing. [See Examples](#open-graph-examples) |
 | `openGraph.videos`                 | array                   | An array of videos (object)                                                                                                                                                          |
 | `openGraph.locale`                 | string                  | The locale the open graph tags are marked up in. Of the format language_TERRITORY. Default is en_US.                                                                                 |
-| `openGraph.site_name`              | string                  | If your object is part of a larger web site, the name which should be displayed for the overall site.                                                                                |
+| `openGraph.siteName`               | string                  | If your object is part of a larger web site, the name which should be displayed for the overall site.                                                                                |
 | `openGraph.profile.firstName`      | string                  | Person's first name.                                                                                                                                                                 |
 | `openGraph.profile.lastName`       | string                  | Person's last name.                                                                                                                                                                  |
 | `openGraph.profile.username`       | string                  | Person's username.                                                                                                                                                                   |
@@ -725,7 +725,7 @@ const Page = () => (
           // Multiple Open Graph tags is only available in version `7.0.2-canary.35`+ of next
           tags: ['Tag A', 'Tag B', 'Tag C'],
         },
-        site_name: 'SiteName',
+        siteName: 'SiteName',
       }}
     />
     <h1>Video Page SEO</h1>

--- a/e2e/next-seo.config.ts
+++ b/e2e/next-seo.config.ts
@@ -66,7 +66,7 @@ const APP_DEFAULT_SEO: DefaultSeoProps = {
         secureUrl: 'https://www.test.ie/secure-og-image-a-01.jpg',
       },
     ],
-    site_name: 'SiteName A',
+    siteName: 'SiteName A',
   },
   twitter: {
     handle: '@handlea',

--- a/e2e/pages/article.tsx
+++ b/e2e/pages/article.tsx
@@ -52,7 +52,7 @@ const Article = () => (
             alt: 'Og Image Alt Article Title D',
           },
         ],
-        site_name: 'SiteName',
+        siteName: 'SiteName',
       }}
       twitter={{
         handle: '@handle',

--- a/e2e/pages/book.tsx
+++ b/e2e/pages/book.tsx
@@ -50,7 +50,7 @@ const Book = () => (
             alt: 'Og Image Alt Book Title D',
           },
         ],
-        site_name: 'SiteName',
+        siteName: 'SiteName',
       }}
       twitter={{
         handle: '@handle',

--- a/e2e/pages/overridden.tsx
+++ b/e2e/pages/overridden.tsx
@@ -61,7 +61,7 @@ const Overridden = () => (
           { url: 'https://www.test.ie/og-video-b-03.jpg' },
           { url: 'https://www.test.ie/og-video-b-04.jpg' },
         ],
-        site_name: 'SiteName B',
+        siteName: 'SiteName B',
       }}
       twitter={{
         handle: '@handleb',

--- a/e2e/pages/profile.tsx
+++ b/e2e/pages/profile.tsx
@@ -45,7 +45,7 @@ const Profile = () => (
             alt: 'Og Image Alt firstlast123 D',
           },
         ],
-        site_name: 'SiteName',
+        siteName: 'SiteName',
       }}
       twitter={{
         handle: '@handle',

--- a/e2e/pages/video.tsx
+++ b/e2e/pages/video.tsx
@@ -66,7 +66,7 @@ const Video = () => (
             alt: 'Og Image Alt Video Title D',
           },
         ],
-        site_name: 'SiteName',
+        siteName: 'SiteName',
       }}
       twitter={{
         handle: '@handle',

--- a/src/meta/__tests__/buildTags.spec.tsx
+++ b/src/meta/__tests__/buildTags.spec.tsx
@@ -90,6 +90,7 @@ const SEO: BuildTagsParams = {
       },
     ],
     site_name: 'SiteName',
+    siteName: 'SiteName',
   },
   twitter: {
     handle: '@handle',
@@ -208,7 +209,7 @@ it('returns full array for default seo object', () => {
   );
   const ogLocaleTag = tags.filter(item => item.key === 'og:locale');
   const ogSiteName = container.querySelectorAll(
-    `meta[content="${SEO.openGraph.site_name}"]`,
+    `meta[content="${SEO.openGraph.siteName || SEO.openGraph?.site_name}"]`,
   );
   const ogSiteNameTag = tags.filter(item => item.key === 'og:site_name');
   const canonicalTag = tags.filter(item => item.key === 'canonical');
@@ -409,6 +410,7 @@ const ArticleSEO = {
         alt: 'Og Image Alt Article Title B',
       },
     ],
+    siteName: 'SiteName',
     site_name: 'SiteName',
   },
   twitter: {
@@ -528,6 +530,7 @@ const BookSEO = {
         alt: 'Og Image Alt Book Title B',
       },
     ],
+    siteName: 'SiteName',
     site_name: 'SiteName',
   },
   twitter: {
@@ -624,6 +627,7 @@ const ProfileSEO = {
         alt: 'Og Image Alt firstlast123 B',
       },
     ],
+    siteName: 'SiteName',
     site_name: 'SiteName',
   },
   twitter: {
@@ -729,6 +733,7 @@ const VideoSEO = {
         alt: 'Og Image Alt Video Title B',
       },
     ],
+    siteName: 'SiteName',
     site_name: 'SiteName',
   },
   twitter: {

--- a/src/meta/buildTags.tsx
+++ b/src/meta/buildTags.tsx
@@ -612,12 +612,12 @@ const buildTags = (config: BuildTagsParams) => {
       );
     }
 
-    if (config.openGraph.site_name) {
+    if (config.openGraph.siteName || config.openGraph.site_name) {
       tagsToRender.push(
         <meta
           key="og:site_name"
           property="og:site_name"
-          content={config.openGraph.site_name}
+          content={config.openGraph.siteName || config.openGraph.site_name}
         />,
       );
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -241,6 +241,7 @@ export interface OpenGraph {
   defaultImageHeight?: number;
   defaultImageWidth?: number;
   locale?: string;
+  siteName?: string;
   site_name?: string;
   profile?: OpenGraphProfile;
   book?: OpenGraphBook;


### PR DESCRIPTION
## Description of Change(s):
ref: https://github.com/garmeeh/next-seo/issues/1011 I updated openGraph tag `site_name` per camel case convention `siteName`. 

I worked during hacktoberfest it's possibly to add label `hacktoberfest` 🙏 

---

To help get PR's merged faster, the following is required:

[x] Updated the documentation
[x] Unit/Cypress test covering all cases

Please link to relevant Google Docs or schema.org docs for what you are adding so we can review.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
