### PR TITLE
adds experience requirements for job posting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1494,6 +1494,15 @@ const Page = () => (
       jobLocationType="TELECOMMUTE"
       validThrough="2020-01-06"
       applicantLocationRequirements="FR"
+      experienceRequirements={{
+        occupational: {
+          minimumMonthsOfExperience: 12,
+        },
+        educational: {
+          credentialCategory: 'high school',
+        },
+        experienceInPlaceOfEducation: true,
+      }}
     />
   </>
 );
@@ -1515,22 +1524,25 @@ export default Page;
 
 **Supported properties**
 
-| Property                        | Info                                                                                                                                                        |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `applicantLocationRequirements` | The geographic location(s) in which employees may be located for to be eligible for the remote job                                                          |
-| `baseSalary`                    |                                                                                                                                                             |
-| `baseSalary.currency`           | The currency in which the monetary amount is expressed                                                                                                      |
-| `baseSalary.value`              | The value of the quantitative value. You can also provide an array of minimum and maximum salaries. .                                                       |
-| `baseSalary.unitText`           | A string indicating the unit of measurement [Base salary guideline](https://developers.google.com/search/docs/data-types/job-posting#basesalary)            |
-| `employmentType`                | Type of employment [Employement type guideline](https://developers.google.com/search/docs/data-types/job-posting#basesalary)                                |
-| `jobLocation`                   | The physical location(s) of the business where the employee will report to work (such as an office or worksite), not the location where the job was posted. |
-| `jobLocation.streetAddress`     | The street address. For example, 1600 Amphitheatre Pkwy                                                                                                     |
-| `jobLocation.addressLocality`   | The locality. For example, Mountain View.                                                                                                                   |
-| `jobLocation.addressRegion`     | The region. For example, CA.                                                                                                                                |
-| `jobLocation.postalCode`        | The postal code. For example, 94043                                                                                                                         |
-| `jobLocation.addressCountry`    | The country. For example, USA. You can also provide the two-letter ISO 3166-1 alpha-2 country code.                                                         |
-| `jobLocationType`               | A description of the job location [Job Location type guideline](https://developers.google.com/search/docs/data-types/job-posting#job-location-type)         |
-| `hiringOrganization.logo`       | Logos on third-party job sites [Hiring Organization guideline](https://developers.google.com/search/docs/data-types/job-posting#hiring)                     |
+| Property                                                        | Info                                                                                                                                                                                                                                                    |
+| --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `applicantLocationRequirements`                                 | The geographic location(s) in which employees may be located for to be eligible for the remote job                                                                                                                                                      |
+| `baseSalary`                                                    |                                                                                                                                                                                                                                                         |
+| `baseSalary.currency`                                           | The currency in which the monetary amount is expressed                                                                                                                                                                                                  |
+| `baseSalary.value`                                              | The value of the quantitative value. You can also provide an array of minimum and maximum salaries. .                                                                                                                                                   |
+| `baseSalary.unitText`                                           | A string indicating the unit of measurement [Base salary guideline](https://developers.google.com/search/docs/data-types/job-posting#basesalary)                                                                                                        |
+| `employmentType`                                                | Type of employment [Employement type guideline](https://developers.google.com/search/docs/data-types/job-posting#basesalary)                                                                                                                            |
+| `jobLocation`                                                   | The physical location(s) of the business where the employee will report to work (such as an office or worksite), not the location where the job was posted.                                                                                             |
+| `jobLocation.streetAddress`                                     | The street address. For example, 1600 Amphitheatre Pkwy                                                                                                                                                                                                 |
+| `jobLocation.addressLocality`                                   | The locality. For example, Mountain View.                                                                                                                                                                                                               |
+| `jobLocation.addressRegion`                                     | The region. For example, CA.                                                                                                                                                                                                                            |
+| `jobLocation.postalCode`                                        | The postal code. For example, 94043                                                                                                                                                                                                                     |
+| `jobLocation.addressCountry`                                    | The country. For example, USA. You can also provide the two-letter ISO 3166-1 alpha-2 country code.                                                                                                                                                     |
+| `jobLocationType`                                               | A description of the job location [Job Location type guideline](https://developers.google.com/search/docs/data-types/job-posting#job-location-type)                                                                                                     |
+| `hiringOrganization.logo`                                       | Logos on third-party job sites [Hiring Organization guideline](https://developers.google.com/search/docs/data-types/job-posting#hiring)                                                                                                                 |
+| `experienceRequirements.occupational.minimumMonthsOfExperience` | The minimum number of months of experience that are required for the job posting. [Experience and Education Requirements](https://developers.google.com/search/docs/appearance/structured-data/job-posting#education-and-experience-properties-beta)    |
+| `experienceRequirements.educational.credentialCategory`         | The level of education that's required for the job posting. Use one of the following: `high school`, `associate degree`, `bachelor degree`, `professional certificate`, `postgraduate degree`                                                           |
+| `experienceRequirements.experienceInPlaceOfEducation`           | Boolean: If set to true, this property indicates whether a job posting will accept experience in place of its formal educational qualifications. If set to true, you must include both the experienceRequirements and educationRequirements properties. |
 
 ### Local Business
 

--- a/cypress/e2e/jobPosting.spec.js
+++ b/cypress/e2e/jobPosting.spec.js
@@ -55,6 +55,15 @@ describe('Job Posting JSON-LD', () => {
         jobLocationType: 'TELECOMMUTE',
         validThrough: '2020-01-06',
         title: 'Job Title',
+        experienceRequirements: {
+          '@type': 'OccupationalExperienceRequirements',
+          monthsOfExperience: 12,
+        },
+        educationRequirements: {
+          '@type': 'EducationalOccupationalCredential',
+          credentialCategory: 'high school',
+        },
+        experienceInPlaceOfEducation: true,
       });
     });
   });

--- a/cypress/schemas/job-posting-schema.js
+++ b/cypress/schemas/job-posting-schema.js
@@ -212,6 +212,62 @@ const applicantLocationRequirements100 = {
   },
 };
 
+const experienceRequirements100 = {
+  version: {
+    major: 1,
+    minor: 0,
+    patch: 0,
+  },
+  schema: {
+    type: 'object',
+    descrption: 'experience requirements for applicants',
+    properties: {
+      '@type': {
+        type: 'string',
+        description: 'type of experience requirement',
+      },
+      monthsOfExperience: {
+        type: 'number',
+        description: 'minimum number of months of experience required',
+      },
+    },
+    required: false,
+    additionalProperties: false,
+    example: {
+      '@type': 'OccupationalExperienceRequirements',
+      monthsOfExperience: '12',
+    },
+  },
+};
+
+const educationRequirements100 = {
+  version: {
+    major: 1,
+    minor: 0,
+    patch: 0,
+  },
+  schema: {
+    type: 'object',
+    descrption: 'education requirements for applicants',
+    properties: {
+      '@type': {
+        type: 'string',
+        description: 'type of education requirement',
+      },
+      credentialCategory: {
+        type: 'string',
+        description: 'minimum education level required',
+      },
+    },
+    required: false,
+    additionalProperties: false,
+    example: {
+      '@type': 'EducationalOccupationalCredential',
+      credentialCategory: 'high school',
+    },
+  },
+};
+
 const jobPosting100 = {
   version: {
     major: 1,
@@ -271,6 +327,19 @@ const jobPosting100 = {
         type: 'string',
         description: 'title of the job offer',
       },
+      experienceRequirements: {
+        ...experienceRequirements100.schema,
+        see: experienceRequirements100,
+      },
+      educationRequirements: {
+        ...educationRequirements100.schema,
+        see: educationRequirements100,
+      },
+      experienceInPlaceOfEducation: {
+        type: 'boolean',
+        description: 'whether experience can be used in place of education',
+        required: false,
+      },
     },
     required: true,
     additionalProperties: false,
@@ -303,6 +372,15 @@ const jobPosting100 = {
       jobLocationType: 'TELECOMMUTE',
       validThrough: '2020-12-12',
       title: 'Software developer',
+      experienceRequirements: {
+        ...experienceRequirements100.example,
+        see: experienceRequirements100,
+      },
+      educationRequirements: {
+        ...educationRequirements100.example,
+        see: educationRequirements100,
+      },
+      experienceInPlaceOfEducation: true,
     },
   },
 };

--- a/e2e/pages/jsonld/jobPosting.tsx
+++ b/e2e/pages/jsonld/jobPosting.tsx
@@ -30,6 +30,11 @@ function JobPosting() {
         jobLocationType="TELECOMMUTE"
         validThrough="2020-01-06"
         applicantLocationRequirements="FR"
+        experienceRequirements={{
+          occupational: { minimumMonthsOfExperience: 12 },
+          educational: { credentialCategory: 'high school' },
+          experienceInPlaceOfEducation: true,
+        }}
       />
 
       <JobPostingJsonLd

--- a/src/jsonld/jobPosting.tsx
+++ b/src/jsonld/jobPosting.tsx
@@ -34,6 +34,27 @@ export type EmploymentType =
   | 'PER_DIEM'
   | 'OTHER';
 
+export type OccupationalExperienceRequirements = {
+  '@type'?: 'OccupationalExperienceRequirements' | 'no requirements' | string;
+  minimumMonthsOfExperience: number;
+};
+
+export type EducationalOccupationalCredential = {
+  '@type'?: 'EducationalOccupationalCredential' | string;
+  credentialCategory:
+    | 'high school'
+    | 'associate degree'
+    | 'bachelor degree'
+    | 'professional certificate'
+    | 'postgraduate degree';
+};
+
+export type ExperienceRequirements = {
+  occupational?: OccupationalExperienceRequirements;
+  educational?: EducationalOccupationalCredential;
+  experienceInPlaceOfEducation?: boolean;
+};
+
 export interface JobPostingJsonLdProps extends JsonLdProps {
   keyOverride?: string;
   datePosted: string;
@@ -46,6 +67,7 @@ export interface JobPostingJsonLdProps extends JsonLdProps {
   employmentType?: EmploymentType | EmploymentType[];
   jobLocation?: Place;
   jobLocationType?: string;
+  experienceRequirements?: ExperienceRequirements;
 }
 
 function JobPostingJsonLd({
@@ -54,6 +76,7 @@ function JobPostingJsonLd({
   baseSalary,
   hiringOrganization,
   applicantLocationRequirements,
+  experienceRequirements,
   jobLocation,
   ...rest
 }: JobPostingJsonLdProps) {
@@ -115,6 +138,34 @@ function JobPostingJsonLd({
     return undefined;
   }
 
+  function setOccupationalExperienceRequirements(
+    requirements?: OccupationalExperienceRequirements,
+  ) {
+    if (requirements) {
+      return {
+        '@type': requirements['@type']
+          ? requirements['@type']
+          : 'OccupationalExperienceRequirements',
+        monthsOfExperience: requirements.minimumMonthsOfExperience,
+      };
+    }
+    return undefined;
+  }
+
+  function setEducationalOccupationalCredential(
+    requirements?: EducationalOccupationalCredential,
+  ) {
+    if (requirements) {
+      return {
+        '@type': requirements['@type']
+          ? requirements['@type']
+          : 'EducationalOccupationalCredential',
+        credentialCategory: requirements.credentialCategory,
+      };
+    }
+    return undefined;
+  }
+
   const data = {
     ...rest,
     baseSalary: setBaseSalary(baseSalary),
@@ -123,6 +174,14 @@ function JobPostingJsonLd({
     applicantLocationRequirements: setApplicantLocationRequirements(
       applicantLocationRequirements,
     ),
+    experienceRequirements: setOccupationalExperienceRequirements(
+      experienceRequirements?.occupational,
+    ),
+    educationRequirements: setEducationalOccupationalCredential(
+      experienceRequirements?.educational,
+    ),
+    experienceInPlaceOfEducation:
+      experienceRequirements?.experienceInPlaceOfEducation,
   };
 
   return (


### PR DESCRIPTION
## Description of Change(s):

This adds an `experienceRequirements` object on the `JobPostingJsonLd` component.

It includes options for occupational experience, educational experience and a boolean for whether experience is accepted in place of education or not.

---

To help get PR's merged faster, the following is required:

[x] Updated the documentation
[x] Unit/Cypress test covering all cases

Please link to relevant Google Docs or schema.org docs for what you are adding so we can review.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
