### PR TITLE
fix(#957): Optional validThrough property for JobPostings

### DIFF
--- a/src/jsonld/jobPosting.tsx
+++ b/src/jsonld/jobPosting.tsx
@@ -61,7 +61,7 @@ export interface JobPostingJsonLdProps extends JsonLdProps {
   description: string;
   hiringOrganization: HiringOrganization;
   title: string;
-  validThrough: string;
+  validThrough?: string;
   applicantLocationRequirements?: string;
   baseSalary?: MonetaryAmount;
   employmentType?: EmploymentType | EmploymentType[];


### PR DESCRIPTION
## Description of Change(s):

---

To help get PR's merged faster, the following is required:

[x] Updated the documentation
[x] Unit/Cypress test covering all cases

---

Not sure if valid through is allowed to be null/undefined, maybe we need to set it to a date such as 9999. But that seems ugly in my opinion.
