### PR TITLE
fix(925): match documentation with contactPoint for organisation

### DIFF
--- a/src/jsonld/corporateContact.tsx
+++ b/src/jsonld/corporateContact.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 import { JsonLd, JsonLdProps } from './jsonld';
 import type { ContactPoint } from 'src/types';
 
-import { setContactPoint } from 'src/utils/schema/setContactPoint';
+import { setContactPoints } from 'src/utils/schema/setContactPoints';
 
 export interface CorporateContactJsonLdProps extends JsonLdProps {
   url: string;
-  contactPoint: ContactPoint[];
+  contactPoint: ContactPoint[] | ContactPoint[];
   logo?: string;
 }
 
@@ -19,7 +19,7 @@ function CorporateContactJsonLd({
 }: CorporateContactJsonLdProps) {
   const data = {
     ...rest,
-    contactPoint: contactPoint.map(setContactPoint),
+    contactPoint: contactPoint && setContactPoints(contactPoint),
   };
   return (
     <JsonLd

--- a/src/jsonld/organization.tsx
+++ b/src/jsonld/organization.tsx
@@ -14,20 +14,23 @@ export interface OrganizationJsonLdProps extends JsonLdProps {
   legalName?: string;
   sameAs?: string[];
   address?: Address;
-  contactPoints?: ContactPoint[];
+  contactPoint?: ContactPoint[] | ContactPoint;
+  /** @deprecated use contactPoint instead. */
+  contactPoints?: ContactPoint[] | ContactPoint
 }
 
 function OrganizationJsonLd({
   type = 'Organization',
   keyOverride,
   address,
+  contactPoint,
   contactPoints,
   ...rest
 }: OrganizationJsonLdProps) {
   const data = {
     ...rest,
     address: setAddress(address),
-    contactPoints: setContactPoints(contactPoints),
+    contactPoint: contactPoint ? setContactPoints(contactPoint) : contactPoints && setContactPoints(contactPoints),
   };
   return (
     <JsonLd

--- a/src/utils/schema/setContactPoints.ts
+++ b/src/utils/schema/setContactPoints.ts
@@ -1,12 +1,10 @@
 import type { ContactPoint } from 'src/types';
+import { setContactPoint } from './setContactPoint';
 
-export function setContactPoints(contactPoint?: ContactPoint[]) {
-  if (contactPoint && contactPoint.length) {
-    return contactPoint.map(contactPoint => ({
-      '@type': 'ContactPoint',
-      ...contactPoint,
-    }));
+export function setContactPoints(contactPoint: ContactPoint[] | ContactPoint) {
+  if (Array.isArray(contactPoint)) {
+    return contactPoint.map(setContactPoint);
   }
 
-  return undefined;
+  return setContactPoint(contactPoint);
 }


### PR DESCRIPTION
## Description of Change(s):

---

To help get PR's merged faster, the following is required:

[*] Updated the documentation
[*] Unit/Cypress test covering all cases

---

Also changed the function in CorporateContact to match the Organisation.
Kept the incorrect contactPoints prop intact but as deprecated to make sure we make no breaking change.
