### PR TITLE
fix: add docs example to avoid httpEquiv TypeScript error

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,32 @@ export default {
 };
 ```
 
+<details><summary>or like this, if you are using TypeScript</summary>
+<p>
+
+```ts
+import { DefaultSeoProps } from 'next-seo';
+
+const config: DefaultSeoProps = {
+  openGraph: {
+    type: 'website',
+    locale: 'en_IE',
+    url: 'https://www.url.ie/',
+    siteName: 'SiteName',
+  },
+  twitter: {
+    handle: '@handle',
+    site: '@site',
+    cardType: 'summary_large_image',
+  },
+};
+
+export default config;
+```
+
+</p>
+</details>
+
 import at the top of `_app.js`
 
 ```jsx


### PR DESCRIPTION
## Description of Change(s):

Fixes #900

The error reported on issue #900 it's not properly a bug.
This issue only happens when using TypeScript, and it's caused by type inference.
When using an external next-seo config file, TypeScript automatically infers `httpEquiv` as a `string` (a wider type).
The `httpEquiv` type extends a `string`. However, `string` does not extend `'content-type' | 'content-security-policy' | 'default-style'...` so it cannot be assigned to it.
The easiest and cleanest way to solve this is to declare the object type inside the config file.
So I've updated the documentation to give an example of the config file that needs to be used in a TypeScript project.

---

To help get PR's merged faster, the following is required:

- [x] Updated the documentation

- [x] Unit/Cypress test covering all cases

Please link to relevant Google Docs or schema.org docs for what you are adding so we can review.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
