### PR TITLE
feat: add isAccessibleForFree prop on article and newsarticle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1074,6 +1074,7 @@ const Page = () => (
       publisherName="Gary Meehan"
       publisherLogo="https://www.example.com/photos/logo.jpg"
       description="This is a mighty good description of this article."
+      isAccessibleForFree={true}
     />
   </>
 );
@@ -2002,6 +2003,7 @@ const Page = () => (
       publisherLogo="https://www.example.com/photos/logo.jpg"
       description="This is a mighty good description of this article."
       body="This is all text for this news article"
+      isAccessibleForFree={true}
     />
   </>
 );

--- a/cypress/e2e/article.spec.js
+++ b/cypress/e2e/article.spec.js
@@ -92,6 +92,7 @@ describe('Article JSON-LD', () => {
           },
         },
         description: 'This is a mighty good description of this article.',
+        isAccessibleForFree: true,
       });
     });
   });

--- a/cypress/e2e/newsarticle.spec.js
+++ b/cypress/e2e/newsarticle.spec.js
@@ -46,6 +46,7 @@ describe('NewsArticle JSON-LD', () => {
         },
         description: 'This is a mighty good description of this news article.',
         articleBody: 'This is article body of news article',
+        isAccessibleForFree: true,
       });
     });
   });

--- a/cypress/schemas/article-schema.js
+++ b/cypress/schemas/article-schema.js
@@ -174,6 +174,12 @@ const article100 = {
         type: 'string',
         description: 'The description of the Article',
       },
+      isAccessibleForFree: {
+        type: 'boolean',
+        description:
+          'A flag to signal that the Article is accessible for free.',
+        required: false,
+      },
     },
     required: true,
     additionalProperties: false,
@@ -206,6 +212,7 @@ const article100 = {
       },
     },
     description: 'This is a mighty good description of this article.',
+    isAccessibleForFree: true,
   },
 };
 

--- a/cypress/schemas/newsarticle-schema.js
+++ b/cypress/schemas/newsarticle-schema.js
@@ -190,6 +190,12 @@ const newsarticle100 = {
         type: 'string',
         description: 'The article body of the News Article',
       },
+      isAccessibleForFree: {
+        type: 'boolean',
+        description:
+          'A flag to signal that the News Article is accessible for free.',
+        required: false,
+      },
     },
     required: true,
     additionalProperties: false,
@@ -226,6 +232,7 @@ const newsarticle100 = {
     },
     description: 'This is a mighty good description of this article.',
     articleBody: 'This is article body of news article',
+    isAccessibleForFree: true,
   },
 };
 

--- a/e2e/pages/jsonld/article.tsx
+++ b/e2e/pages/jsonld/article.tsx
@@ -28,6 +28,7 @@ function Article() {
         publisherName="Gary Meehan"
         publisherLogo="https://www.example.com/photos/logo.jpg"
         description="This is a mighty good description of this article."
+        isAccessibleForFree={true}
       />
     </>
   );

--- a/e2e/pages/jsonld/newsarticle.tsx
+++ b/e2e/pages/jsonld/newsarticle.tsx
@@ -23,6 +23,7 @@ function NewsArticle() {
         publisherLogo="https://www.example.com/photos/logo.jpg"
         description="This is a mighty good description of this news article."
         body="This is article body of news article"
+        isAccessibleForFree={true}
       />
     </>
   );

--- a/src/jsonld/article.tsx
+++ b/src/jsonld/article.tsx
@@ -16,6 +16,7 @@ export interface ArticleJsonLdProps extends JsonLdProps {
   description: string;
   publisherName?: string;
   publisherLogo?: string;
+  isAccessibleForFree?: boolean;
 }
 
 function ArticleJsonLd({
@@ -30,6 +31,7 @@ function ArticleJsonLd({
   publisherName = undefined,
   publisherLogo = undefined,
   description,
+  isAccessibleForFree,
 }: ArticleJsonLdProps) {
   const data = {
     datePublished,
@@ -43,6 +45,7 @@ function ArticleJsonLd({
     dateModified: dateModified || datePublished,
     author: setAuthor(authorName),
     publisher: setPublisher(publisherName, publisherLogo),
+    isAccessibleForFree: isAccessibleForFree,
   };
   return (
     <JsonLd

--- a/src/jsonld/newsarticle.tsx
+++ b/src/jsonld/newsarticle.tsx
@@ -18,6 +18,7 @@ export interface NewsArticleJsonLdProps extends JsonLdProps {
   body: string;
   publisherName: string;
   publisherLogo: string;
+  isAccessibleForFree?: boolean;
 }
 
 function NewsArticleJsonLd({
@@ -34,6 +35,7 @@ function NewsArticleJsonLd({
   publisherName,
   publisherLogo,
   body,
+  isAccessibleForFree,
   ...rest
 }: NewsArticleJsonLdProps) {
   const data = {
@@ -51,6 +53,7 @@ function NewsArticleJsonLd({
     author: setAuthor(authorName),
     publisher: setPublisher(publisherName, publisherLogo),
     articleBody: body,
+    isAccessibleForFree: isAccessibleForFree,
   };
 
   return (


### PR DESCRIPTION
## Description of Change(s):

Fixes #902

This property is really useful when working with paywalled articles.

Read more: [Paywalled Content](https://developers.google.com/search/docs/appearance/structured-data/paywalled-content).

---

To help get PR's merged faster, the following is required:

- [x] Updated the documentation
- [x] Unit/Cypress test covering all cases

Please link to relevant Google Docs or schema.org docs for what you are adding so we can review.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
