### PR TITLE
fix: product can have a single review

### DIFF
--- a/src/jsonld/product.tsx
+++ b/src/jsonld/product.tsx
@@ -20,7 +20,7 @@ export interface ProductJsonLdProps extends JsonLdProps {
   images?: string[];
   description?: string;
   brand?: string;
-  reviews?: Review[];
+  reviews?: Review | Review[];
   aggregateRating?: AggregateRating;
   offers?: Offers | Offers[];
   aggregateOffer?: AggregateOffer;


### PR DESCRIPTION
## Description of Change(s):

`Product` can have a single `Review`. This is actually what Google recommends.

https://developers.google.com/search/docs/appearance/structured-data/product#product-review-page-example

---

To help get PR's merged faster, the following is required:

[ ] Updated the documentation
[ ] Unit/Cypress test covering all cases

Please link to relevant Google Docs or schema.org docs for what you are adding so we can review.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
