### PR TITLE
feat: enhance NewsArticleJsonLd and ArticleJsonLd author

### DIFF
--- a/src/jsonld/newsarticle.tsx
+++ b/src/jsonld/newsarticle.tsx
@@ -3,6 +3,7 @@ import { setAuthor } from 'src/utils/schema/setAuthor';
 import { setPublisher } from 'src/utils/schema/setPublisher';
 
 import { JsonLd, JsonLdProps } from './jsonld';
+import { ArticleAuthor } from '../types';
 
 export interface NewsArticleJsonLdProps extends JsonLdProps {
   url: string;
@@ -13,7 +14,7 @@ export interface NewsArticleJsonLdProps extends JsonLdProps {
   dateCreated: string;
   datePublished: string;
   dateModified?: string;
-  authorName: string | string[];
+  authorName: string | string[] | ArticleAuthor | ArticleAuthor[];
   description: string;
   body: string;
   publisherName: string;
@@ -32,6 +33,7 @@ function NewsArticleJsonLd({
   datePublished,
   dateModified,
   authorName,
+  authorType,
   publisherName,
   publisherLogo,
   body,

--- a/src/types.ts
+++ b/src/types.ts
@@ -378,7 +378,8 @@ export type Author = {
 
 export type ArticleAuthor = {
   name: string;
-  url: string;
+  url?: string;
+  type?: 'Person' | 'Organization';
 };
 
 export type Publisher = {

--- a/src/utils/schema/__tests__/setAuthor.test.ts
+++ b/src/utils/schema/__tests__/setAuthor.test.ts
@@ -1,0 +1,79 @@
+import { ArticleAuthor } from 'src/types';
+import { setAuthor } from '../setAuthor';
+
+describe('setAuthor', () => {
+  test('should return undefined if author is undefined', () => {
+    expect(setAuthor(undefined)).toBeUndefined();
+  });
+
+  test('works correctly when ArticleAuthor is passed', () => {
+    const author: ArticleAuthor = {
+      name: 'Acme',
+      type: 'Organization',
+      url: '/acme',
+    };
+
+    const data = setAuthor(author);
+
+    expect(data).toEqual({
+      '@type': 'Organization',
+      name: 'Acme',
+      url: '/acme',
+    });
+  });
+
+  test('works correctly when just ArticleAuthor name is passed', () => {
+    const data = setAuthor({ name: 'John Doe' });
+
+    expect(data).toEqual({
+      '@type': 'Person',
+      name: 'John Doe',
+    });
+  });
+
+  test('works correctly when an array of ArticleAuthor is passed', () => {
+    const author: ArticleAuthor[] = [
+      {
+        name: 'Acme',
+        type: 'Organization',
+        url: '/acme',
+      },
+      { name: 'John Doe' },
+    ];
+
+    const data = setAuthor(author);
+
+    expect(data).toEqual([
+      {
+        '@type': 'Organization',
+        name: 'Acme',
+        url: '/acme',
+      },
+      { '@type': 'Person', name: 'John Doe' },
+    ]);
+  });
+
+  test('works correctly when string is passed', () => {
+    const data = setAuthor('John Doe');
+
+    expect(data).toEqual({
+      '@type': 'Person',
+      name: 'John Doe',
+    });
+  });
+
+  test('works correctly when an array string is passed', () => {
+    const data = setAuthor(['John Doe', 'Foo Bar']);
+
+    expect(data).toEqual([
+      {
+        '@type': 'Person',
+        name: 'John Doe',
+      },
+      {
+        '@type': 'Person',
+        name: 'Foo Bar',
+      },
+    ]);
+  });
+});

--- a/src/utils/schema/setAuthor.ts
+++ b/src/utils/schema/setAuthor.ts
@@ -1,15 +1,6 @@
 import { ArticleAuthor } from '../../types';
 
 /**
- * Include name and url
- * @param author
- * @returns
- */
-function includeNameAndUrl(author: ArticleAuthor): boolean {
-  return typeof author === 'object' && !!(author.name && author.url);
-}
-
-/**
  * Generate author information
  * @param author
  * @returns
@@ -20,11 +11,11 @@ function generateAuthorInfo(author: string | ArticleAuthor) {
       '@type': 'Person',
       name: author,
     };
-  } else if (includeNameAndUrl(author)) {
+  } else if (!!author.name) {
     return {
-      '@type': 'Person',
+      '@type': author?.type ?? 'Person',
       name: author.name,
-      url: author.url,
+      url: author?.url,
     };
   }
 


### PR DESCRIPTION
## Description of Change(s):

`NewsArticleJsonLd` author couldn't be customised with `@type` and `url` parameter.
With this PR `NewsArticleJsonLd` `authorName` prop accepts also `ArticleAuthor`.

Also there was no way to override `@type` property of `author`. With this PR the default is set to `Person` but can be customised.

---

To help get PR's merged faster, the following is required:

[] Updated the documentation
[x] Unit/Cypress test covering all cases

Please link to relevant Google Docs or schema.org docs for what you are adding so we can review.
* https://schema.org/NewsArticle
* https://schema.org/author

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
