### PR TITLE
chore: Allow null for TS definitions about width and height of OpenGraphMedia 

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -155,8 +155,8 @@ export interface ItemListElements {
 }
 export interface OpenGraphMedia {
   url: string;
-  width?: number;
-  height?: number;
+  width?: number | null;
+  height?: number | null;
   alt?: string;
   type?: string;
   secureUrl?: string;


### PR DESCRIPTION
Refs issue : https://github.com/garmeeh/next-seo/issues/975

## Description of Change(s):

---

To help get PR's merged faster, the following is required:

[ ] Updated the documentation
[V] Unit/Cypress test covering all cases

<img width="922" alt="image" src="https://user-images.githubusercontent.com/44645706/203917976-9950f1cf-3447-4d34-8287-6cb004ac82de.png">

<img width="565" alt="image" src="https://user-images.githubusercontent.com/44645706/203918065-db7055a9-20c2-46c6-a095-e94ec9bf121d.png">



Please link to relevant Google Docs or schema.org docs for what you are adding so we can review.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
