### PR TITLE
fix: typo in e2e app

### DIFF
--- a/e2e/pages/jsonld/index.tsx
+++ b/e2e/pages/jsonld/index.tsx
@@ -10,7 +10,7 @@ const allJsonLDPages = [
   'corporateContact',
   'course',
   'dataset',
-  'even',
+  'event',
   'faq',
   'howTo',
   'jobPosting',


### PR DESCRIPTION
## Description of Change(s):

There is a typo in e2e app `/jsonld`:

- :x: `even`
- :o: `event`

<img width="321" alt="image" src="https://user-images.githubusercontent.com/7803255/205447187-63bb85e5-ee4f-4800-9e17-038477b63ce2.png">


---

To help get PR's merged faster, the following is required:

[] ~Updated the documentation~
[] ~Unit/Cypress test covering all cases~

Please link to relevant Google Docs or schema.org docs for what you are adding so we can review.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
