### PR TITLE
fix(EventJsonLd): Do not add `eventStatus`/`eventAttendanceMode` if not present

### DIFF
--- a/src/jsonld/event.tsx
+++ b/src/jsonld/event.tsx
@@ -56,8 +56,10 @@ function EventJsonLd({
     organizer: Array.isArray(organizer)
       ? organizer.map(setOrganizer)
       : setOrganizer(organizer),
-    eventStatus: `https://schema.org/${eventStatus}`,
-    eventAttendanceMode: `https://schema.org/${eventAttendanceMode}`,
+    eventStatus: eventStatus ? `https://schema.org/${eventStatus}` : undefined,
+    eventAttendanceMode: eventAttendanceMode
+      ? `https://schema.org/${eventAttendanceMode}`
+      : undefined,
   };
 
   return (


### PR DESCRIPTION
## Description of Change(s):

Fixes #1115 . Set `undefined` to `eventStatus`/`eventAttendanceMode` if they are not present.

---

To help get PR's merged faster, the following is required:

[] ~Updated the documentation~
[x] Unit/Cypress test covering all cases

Please link to relevant Google Docs or schema.org docs for what you are adding so we can review.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
