### PR TITLE
fix: Accept type string for `location` and `address`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -95,7 +95,7 @@ export interface VirtualLocation {
   url: string;
 }
 
-export type Location = Place | VirtualLocation;
+export type Location = string | Place | VirtualLocation;
 
 export type EventStatus =
   | 'EventCancelled'
@@ -162,13 +162,15 @@ export interface OpenGraphMedia {
   secureUrl?: string;
 }
 
-export interface Address {
-  streetAddress: string;
-  addressLocality: string;
-  addressRegion?: string;
-  postalCode: string;
-  addressCountry: string;
-}
+export type Address =
+  | string
+  | {
+      streetAddress: string;
+      addressLocality: string;
+      addressRegion?: string;
+      postalCode: string;
+      addressCountry: string;
+    };
 
 export interface Video {
   name: string;

--- a/src/utils/schema/__tests__/setAddress.test.ts
+++ b/src/utils/schema/__tests__/setAddress.test.ts
@@ -22,6 +22,10 @@ describe('setAddress', () => {
     expect(setAddress(undefined)).toBeUndefined();
   });
 
+  test('should accepts simple string and returns it', () => {
+    expect(setAddress('AddressText')).toBe('AddressText');
+  });
+
   test('single address returns correctly', () => {
     const data = setAddress(addressOne);
 

--- a/src/utils/schema/__tests__/setLocation.test.ts
+++ b/src/utils/schema/__tests__/setLocation.test.ts
@@ -1,0 +1,37 @@
+import { Place, VirtualLocation } from 'src/types';
+import { setLocation } from '../setLocation';
+
+const virtualLocation: VirtualLocation = {
+  name: 'Virtual Location',
+  sameAs: 'https://example.com',
+  url: 'https://example.com',
+};
+
+const place: Place = {
+  name: 'Place',
+  address: 'Address String',
+};
+
+describe('setLocation', () => {
+  test('should return undefined if location is undefined', () => {
+    expect(setLocation(undefined)).toBeUndefined();
+  });
+
+  test('should accepts simple string and returns it', () => {
+    expect(setLocation('LocationText')).toBe('LocationText');
+  });
+
+  test('returns VirtualLocation correctly', () => {
+    expect(setLocation(virtualLocation)).toMatchObject({
+      '@type': 'VirtualLocation',
+      ...virtualLocation,
+    });
+  });
+
+  test('returns Place correctly', () => {
+    expect(setLocation(place)).toMatchObject({
+      '@type': 'Place',
+      ...place,
+    });
+  });
+});

--- a/src/utils/schema/setAddress.ts
+++ b/src/utils/schema/setAddress.ts
@@ -2,7 +2,7 @@ import { Address } from 'src/types';
 
 export function setAddress(address?: Address | Address[]) {
   if (!address) return undefined;
-  
+
   if (!Array.isArray(address)) return toPostalAddress(address);
 
   // If array of one address, replace with single address
@@ -13,5 +13,6 @@ export function setAddress(address?: Address | Address[]) {
 }
 
 function toPostalAddress(address: Address) {
+  if (typeof address === 'string') return address;
   return { '@type': 'PostalAddress', ...address };
 }

--- a/src/utils/schema/setLocation.ts
+++ b/src/utils/schema/setLocation.ts
@@ -1,9 +1,13 @@
 import { Location, Place, VirtualLocation } from 'src/types';
 import { setAddress } from './setAddress';
 
-export function setLocation(location: Location) {
+export function setLocation(location?: Location) {
   if (!location) {
     return undefined;
+  }
+
+  if (typeof location === 'string') {
+    return location;
   }
 
   if ('url' in location) {


### PR DESCRIPTION
## Description of Change(s):

Fixes #1116

- `type Location` now includes `string` (cf: [location](https://schema.org/location))
- `type Address` now includes `string` (cf: [address](https://schema.org/address))
- `setLocation()` and `setAddress` return string itself for parameters with type string
- Add unit tests

---

To help get PR's merged faster, the following is required:

- [ ] ~Updated the documentation~
- [x] Unit/Cypress test covering all cases

Please link to relevant Google Docs or schema.org docs for what you are adding so we can review.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
