### PR TITLE
Add cateogry property to product json-ld prop type

### DIFF
--- a/src/jsonld/product.tsx
+++ b/src/jsonld/product.tsx
@@ -39,6 +39,7 @@ export interface ProductJsonLdProps extends JsonLdProps {
   purchaseDate?: string;
   releaseDate?: string;
   award?: string;
+  category?: string
 }
 
 function ProductJsonLd({


### PR DESCRIPTION
## Description of Change(s):
- Add `category` property to `ProductJsonLdProps` type – ensuring the Product props are defined according to https://schema.org/Product 

---

To help get PR's merged faster, the following is required:

--> As it's a single optional prop type, no additional tests are necessary.

[ ] Updated the documentation
[ ] Unit/Cypress test covering all cases

Please link to relevant Google Docs or schema.org docs for what you are adding so we can review.

- https://schema.org/Product 

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
