### PR TITLE
fix: #1118 - added worstRating under AggregateRating type

### DIFF
--- a/README.md
+++ b/README.md
@@ -2255,6 +2255,7 @@ const Page = () => (
         reviewCount: '89',
         ratingCount: '684',
         bestRating: '100',
+        worstRating: '1',
       }}
       reviews={[
         {
@@ -3177,6 +3178,7 @@ export default () => (
 | `aggregateRating.ratingCount` | The count of total number of ratings.                                                    |
 | `aggregateRating.reviewCount` | The count of total number of reviews.                                                    |
 | `aggregateRating.bestRating`  | The highest value allowed in this rating system. If bestRating is omitted, 5 is assumed. |
+| `aggregateRating.worstRating` | The lowest value allowed in this rating system. If worstRating is omitted, 1 is assumed. |
 
 **Other**
 | `useAppDir` | This should be set to true if using new app directory. Not required if outside of app directory. |

--- a/src/types.ts
+++ b/src/types.ts
@@ -359,6 +359,7 @@ export type AggregateRating = {
   reviewCount?: string;
   ratingCount?: string;
   bestRating?: string;
+  worstRating?: string;
 };
 
 export type GamePlayMode = 'CoOp' | 'MultiPlayer' | 'SinglePlayer';

--- a/src/utils/schema/__tests__/setAggregateRating.test.ts
+++ b/src/utils/schema/__tests__/setAggregateRating.test.ts
@@ -6,6 +6,7 @@ const aggregateRating: AggregateRating = {
   reviewCount: '100',
   ratingCount: '100',
   bestRating: '5',
+  worstRating: '1',
 };
 
 describe('setAggregateOffer', () => {

--- a/src/utils/schema/setAggregateRating.ts
+++ b/src/utils/schema/setAggregateRating.ts
@@ -8,6 +8,7 @@ export function setAggregateRating(aggregateRating?: AggregateRating) {
       reviewCount: aggregateRating.reviewCount,
       bestRating: aggregateRating.bestRating,
       ratingValue: aggregateRating.ratingValue,
+      worstRating: aggregateRating.worstRating,
     };
   }
   return undefined;


### PR DESCRIPTION
## Description of Change(s):

Fixes #1118 
- Added worstRating under AggregateRating type & schema. Also added in tests & documentation.

---

To help get PR's merged faster, the following is required:

[] Updated the documentation
[] Unit/Cypress test covering all cases

Please link to relevant Google Docs or schema.org docs for what you are adding so we can review.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
