### PR TITLE
Make sub fields for Place on JobPostingJsonLd optional

### DIFF
--- a/src/jsonld/jobPosting.tsx
+++ b/src/jsonld/jobPosting.tsx
@@ -9,10 +9,10 @@ export interface HiringOrganization {
 }
 
 export interface Place {
-  addressLocality: string;
-  addressRegion: string;
-  postalCode: string;
-  streetAddress: string;
+  addressLocality?: string;
+  addressRegion?: string;
+  postalCode?: string;
+  streetAddress?: string;
   addressCountry: string;
 }
 


### PR DESCRIPTION
## Description of Change(s):

The subfields of the Place interface for JobPostingJsonLd , other than addressCountry, are optional per google spec: https://developers.google.com/search/docs/appearance/structured-data/job-posting#basesalary:~:text=Include%20as%20many%20properties%20as%20possible.%20The%20more%20properties%20you%20provide%2C%20the%20higher%20quality%20the%20job%20posting%20is%20to%20our%20users.%20Note%20that%20you%20must%20include%20the%20addressCountry%20property
