### PR TITLE
feat(jsonld): adds keywords for SoftwareApp schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -3027,6 +3027,7 @@ export default () => (
       aggregateRating={{ ratingValue: '4.6', reviewCount: '8864' }}
       operatingSystem="ANDROID"
       applicationCategory="GameApplication"
+      keywords="angrybirds, arcade, slingshot"
     />
   </>
 );
@@ -3052,7 +3053,13 @@ export default () => (
 | `operatingSystem`     | The operating System supported by the game it self. |
 | `applicationCategory` | Desktop Software or Video Game...                   |
 
-For reference and more info check [Google docs for Software App](https://developers.google.com/search/docs/data-types/software-app)
+**Data other properties**
+
+| Property   | Info                                                                                                                   |
+| ---------- | ---------------------------------------------------------------------------------------------------------------------- |
+| `keywords` | Keywords or tags used to describe this content. Multiple entries in a keywords list are typically delimited by commas. |
+
+For reference and more info check [Google docs for Software App](https://developers.google.com/search/docs/data-types/software-app) and [Schema.org docs](https://schema.org/SoftwareApplication)
 
 ### Organization
 

--- a/cypress/e2e/softwareApp.spec.js
+++ b/cypress/e2e/softwareApp.spec.js
@@ -30,6 +30,7 @@ describe('SoftwareApp JSON-LD', () => {
           price: '1.00',
           priceCurrency: 'USD',
         },
+        keywords: 'angrybirds, arcade, slingshot',
       });
     });
   });

--- a/cypress/schemas/software-app-schema.js
+++ b/cypress/schemas/software-app-schema.js
@@ -52,6 +52,9 @@ const softwareApp100 = {
           },
         },
       },
+      keywords: {
+        type: 'string',
+      },
     },
   },
   example: {
@@ -70,6 +73,7 @@ const softwareApp100 = {
       price: '1.00',
       priceCurrency: 'USD',
     },
+    keywords: 'angrybirds, arcade, slingshot',
   },
 };
 

--- a/e2e/pages/jsonld/softwareApp.tsx
+++ b/e2e/pages/jsonld/softwareApp.tsx
@@ -12,6 +12,7 @@ function SoftwareApp() {
         aggregateRating={{ ratingValue: '4.6', ratingCount: '8864' }}
         operatingSystem="ANDROID"
         applicationCategory="GameApplication"
+        keywords="angrybirds, arcade, slingshot"
       />
     </>
   );

--- a/src/jsonld/softwareApp.tsx
+++ b/src/jsonld/softwareApp.tsx
@@ -13,6 +13,7 @@ export interface SoftwareAppJsonLdProps extends JsonLdProps {
   operatingSystem?: string;
   review?: Review;
   aggregateRating?: AggregateRating;
+  keywords?: string;
 }
 
 function SoftwareAppJsonLd({
@@ -22,6 +23,7 @@ function SoftwareAppJsonLd({
   price,
   aggregateRating,
   review,
+  keywords,
   ...rest
 }: SoftwareAppJsonLdProps) {
   const data = {
@@ -33,6 +35,7 @@ function SoftwareAppJsonLd({
     },
     aggregateRating: setAggregateRating(aggregateRating),
     review: setReviews(review),
+    keywords,
   };
   return (
     <JsonLd


### PR DESCRIPTION
## Description of Change(s):
Fixes https://github.com/garmeeh/next-seo/issues/1240
Adds an optional "keywords" property to the SoftwareApp schema

---

To help get PR's merged faster, the following is required:

- [x] Updated the documentation
- [x] Unit/Cypress test covering all cases

Please link to relevant Google Docs or schema.org docs for what you are adding so we can review.
[Shema.org docs] (https://schema.org/SoftwareApplication)

---

I'm not sure about the "Data other properties" section, but this property is not on Google's Recommended list
