### PR TITLE
Remove keyoverride attribute from additional link tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you are using **`pages`** directory then `NextSeo` is **exactly what you need
     - [dangerouslySetAllPagesToNoFollow](#dangerouslysetallpagestonofollow)
     - [robotsProps](#robotsprops)
     - [Twitter](#twitter)
-    - [facebook](#facebook)
+    - [Facebook](#facebook)
     - [Canonical URL](#canonical-url)
     - [Alternate](#alternate)
     - [Additional Meta Tags](#additional-meta-tags)

--- a/src/meta/__tests__/buildTags.spec.tsx
+++ b/src/meta/__tests__/buildTags.spec.tsx
@@ -976,3 +976,37 @@ it('correctly read all robots props', () => {
   expect(Array.from(content).length).toBe(0);
   expect(Array.from(contentOverride).length).toBe(1);
 });
+
+it('additional link tags are set', () => {
+  const overrideProps: BuildTagsParams = {
+    ...SEO,
+    additionalLinkTags: [
+      {
+        rel: 'apple-touch-icon',
+        href: 'https://www.test.ie/touch-icon-ipad.jpg',
+        sizes: '76x76',
+        keyOverride: '76x76',
+      },
+      {
+        rel: 'apple-touch-icon',
+        href: 'https://www.test.ie/touch-icon-ipad.jpg',
+        sizes: '120x120',
+        keyOverride: '120x120',
+      },
+      {
+        rel: 'icon',
+        href: 'https://www.test.ie/favicon.ico',
+      },
+    ],
+  };
+  const tags = buildTags(overrideProps);
+  const { container } = render(<>{React.Children.toArray(tags)}</>);
+  const appleTouchIconTags = container.querySelectorAll(
+    'link[rel="apple-touch-icon"]',
+  );
+  expect(Array.from(appleTouchIconTags).length).toBe(2);
+  expect(appleTouchIconTags[0]).not.toHaveAttribute('keyoverride');
+
+  const iconTags = container.querySelectorAll('link[rel="icon"]');
+  expect(Array.from(iconTags).length).toBe(1);
+});

--- a/src/meta/buildTags.tsx
+++ b/src/meta/buildTags.tsx
@@ -659,7 +659,7 @@ const buildTags = (config: BuildTagsParams) => {
 
   if (config.additionalLinkTags?.length) {
     config.additionalLinkTags.forEach(tag => {
-      const { crossOrigin: tagCrossOrigin, ...rest } = tag;
+      const { crossOrigin: tagCrossOrigin, keyOverride, ...rest } = tag;
       const crossOrigin: 'anonymous' | 'use-credentials' | '' | undefined =
         tagCrossOrigin === 'anonymous' ||
         tagCrossOrigin === 'use-credentials' ||
@@ -669,7 +669,7 @@ const buildTags = (config: BuildTagsParams) => {
 
       tagsToRender.push(
         <link
-          key={`link${rest.keyOverride ?? rest.href}${rest.rel}`}
+          key={`link${keyOverride ?? rest.href}${rest.rel}`}
           {...rest}
           crossOrigin={crossOrigin}
         />,


### PR DESCRIPTION
## Description of Change(s):
Stops the keyOverride prop for additionalLinkTags being rendered as a keyoverride attribute.

## Related issue and PR
- https://github.com/garmeeh/next-seo/issues/1079
- https://github.com/garmeeh/next-seo/pull/1080
---

To help get PR's merged faster, the following is required:

[] Updated the documentation
[x] Unit/Cypress test covering all cases

Please link to relevant Google Docs or schema.org docs for what you are adding so we can review.

Please have a read of the Contributing Guide for full details.

https://github.com/garmeeh/next-seo/blob/master/CONTRIBUTING.md
