### PR TITLE
fix: export all types from './types' for improved accessibility

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,4 +72,4 @@ export {
   CampgroundJsonLdProps,
 } from './jsonld/campground';
 export { default as ParkJsonLd, ParkJsonLdProps } from './jsonld/park';
-export { DefaultSeoProps, NextSeoProps } from './types';
+export * from './types';


### PR DESCRIPTION
Hey @garmeeh, 
This PR export all TypeScript types from `src/types.ts` to make them available for package consumers. This change adds `export * from './types';` to `src/index.tsx`, allowing developers to import and use all type definitions directly from the next-seo package.

**Changes made:**
- Added `export * from './types';` to `src/index.tsx`
- All 36+ types from `src/types.ts` are now publicly available
- Maintains backward compatibility with existing exports

**Benefits:**
- Enables proper TypeScript support for consumers
- Provides full IDE autocomplete and type checking
- Allows importing types like `EventStatus`, `EventAttendanceMode`, `HTML5MetaTag`, `Address`, etc.
- Fixes build errors when trying to use next-seo types in TypeScript projects

**Related issues**

Closes: #1478