### PR TITLE
fix: add JsonLd and JsonLdProps exports to index

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -72,4 +72,5 @@ export {
   CampgroundJsonLdProps,
 } from './jsonld/campground';
 export { default as ParkJsonLd, ParkJsonLdProps } from './jsonld/park';
+export { JsonLd, JsonLdProps } from './jsonld/jsonld';
 export { DefaultSeoProps, NextSeoProps } from './types';


### PR DESCRIPTION
Hi @garmeeh,
Export the base `JsonLd` component and `JsonLdProps` interface to allow developers to create custom JSON-LD components. This addresses the need for more flexibility when the built-in components don't cover all schema.org types or when additional properties are needed.

**Changes made:**
- Added `export { JsonLd, JsonLdProps } from './jsonld/jsonld';` to `src/index.tsx`
- Base `JsonLd` component is now publicly available for creating custom JSON-LD components
- Maintains backward compatibility with all existing components

**Benefits:**
- Enables developers to create custom JSON-LD components for unsupported schema.org types
- Allows extending existing components with additional properties
- Provides flexibility for edge cases not covered by built-in components
- Follows the principle of composition over creating countless specific components

**Use cases this enables:**
```typescript
import { JsonLd, JsonLdProps } from 'next-seo';

// Custom LiveBlogPosting component (requested in #1468)
interface LiveBlogPostingJsonLdProps extends JsonLdProps {
  headline: string;
  coverageStartTime: string;
}

export function LiveBlogPostingJsonLd({ headline, coverageStartTime, ...props }: LiveBlogPostingJsonLdProps) {
  return (
    <JsonLd 
      type="LiveBlogPosting"
      headline={headline}
      coverageStartTime={coverageStartTime}
      {...props}
      scriptKey="liveblogposting"
    />
  );
}

// Custom WebSite component (requested in #1472)
// Extended WebPage with additional props (requested in #1482)
```

**Related issues**

Addresses: #1482 (alternative solution mentioned in the issue)
Enables: #1468 (LiveBlogPosting can now be implemented by users)
Enables: #1472 (WebSiteJsonLd can now be implemented by users)