### PR TITLE
Adding carousel beta options. Making custom fully configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ If you are using **`pages`** directory then `NextSeo` is **exactly what you need
   - [Collection Page](#collection-page)
   - [Profile page](#profile-page)
   - [Carousel](#carousel)
+    - [Google Carousels (Beta)](#google-carousels-beta)
+      - [LocalBusiness Example](#localbusiness-example)
+      - [Product Example](#product-example)
+      - [Event Example](#event-example)
     - [Default (Summary List)](#default-summary-list)
     - [Course](#course-1)
     - [Movie](#movie)
@@ -2890,6 +2894,129 @@ export default Page;
 For reference and more info check [Profile Page DataType](https://schema.org/ProfilePage)
 
 ### Carousel
+
+#### Google Carousels (Beta)
+
+**[BETA]** Google Search now supports carousels for LocalBusiness (and subtypes), Product, and Event. See [official docs](https://developers.google.com/search/docs/appearance/structured-data/carousels-beta).
+
+##### LocalBusiness Example
+
+```jsx
+import React from 'react';
+import { CarouselJsonLd } from 'next-seo';
+
+export default () => (
+  <>
+    <h1>Carousel LocalBusiness JSON-LD</h1>
+    <CarouselJsonLd
+      ofType="localBusiness"
+      data={[
+        {
+          name: 'Test Hotel',
+          url: 'http://example.com/hotel-1.html',
+          image: [
+            'https://example.com/photos/1x1/photo.jpg',
+            'https://example.com/photos/4x3/photo.jpg',
+            'https://example.com/photos/16x9/photo.jpg',
+          ],
+          priceRange: '$$$',
+          amenityFeature: {
+            '@type': 'LocationFeatureSpecification',
+            name: 'freeWifi',
+            value: true,
+          },
+          aggregateRating: { ratingValue: 4.8, reviewCount: 100 },
+        },
+        // ...more items
+      ]}
+    />
+  </>
+);
+```
+
+**Required properties:**
+
+| Property | Info                   |
+| -------- | ---------------------- |
+| `name`   | Name of the business   |
+| `url`    | URL of the detail page |
+| `image`  | Array of image URLs    |
+
+**Recommended:** `priceRange`, `servesCuisine`, `amenityFeature`, `aggregateRating`
+
+##### Product Example
+
+```jsx
+<CarouselJsonLd
+  ofType="product"
+  data={[
+    {
+      name: 'Test Product',
+      url: 'http://example.com/product-1.html',
+      image: [
+        'https://example.com/photos/1x1/photo.jpg',
+        'https://example.com/photos/4x3/photo.jpg',
+        'https://example.com/photos/16x9/photo.jpg',
+      ],
+      offers: {
+        '@type': 'Offer',
+        price: 99.99,
+        priceCurrency: 'USD',
+      },
+      aggregateRating: { ratingValue: 4.5, reviewCount: 50 },
+    },
+    // ...more items
+  ]}
+/>
+```
+
+**Required properties:**
+
+| Property | Info                           |
+| -------- | ------------------------------ |
+| `name`   | Name of the product            |
+| `url`    | URL of the detail page         |
+| `image`  | Array of image URLs            |
+| `offers` | Offer or AggregateOffer object |
+
+**Recommended:** `aggregateRating`
+
+##### Event Example
+
+```jsx
+<CarouselJsonLd
+  ofType="event"
+  data={[
+    {
+      name: 'Test Event',
+      url: 'http://example.com/event-1.html',
+      image: [
+        'https://example.com/photos/1x1/photo.jpg',
+        'https://example.com/photos/4x3/photo.jpg',
+        'https://example.com/photos/16x9/photo.jpg',
+      ],
+      offers: {
+        '@type': 'Offer',
+        price: 10,
+        priceCurrency: 'EUR',
+      },
+      aggregateRating: { ratingValue: 4.2, reviewCount: 20 },
+    },
+    // ...more items
+  ]}
+/>
+```
+
+**Required properties:**
+
+| Property | Info                           |
+| -------- | ------------------------------ |
+| `name`   | Name of the event              |
+| `url`    | URL of the detail page         |
+| `image`  | Array of image URLs            |
+| `offers` | Offer or AggregateOffer object |
+
+**Recommended:** `aggregateRating`
 
 **Required properties of Carousel Component**
 

--- a/cypress/schemas/event-schema.js
+++ b/cypress/schemas/event-schema.js
@@ -1,7 +1,7 @@
 import { versionSchemas } from '@cypress/schema-tools';
 
 import address100 from './address';
-import { offers101 } from "./common"
+import { offers101 } from './common';
 
 const location100 = {
   version: {
@@ -142,7 +142,7 @@ const event100 = {
     performer: {
       '@type': 'PerformingGroup',
       name: 'Kira and Morrison',
-    }
+    },
   },
 };
 

--- a/cypress/schemas/index.js
+++ b/cypress/schemas/index.js
@@ -30,7 +30,6 @@ import imageVersions from './image-schema';
 import campgroundVersions from './campground-schema';
 import parkVersions from './park-schema';
 
-
 const schemas = combineSchemas(
   articleVersions,
   breadCrumbVersions,

--- a/cypress/schemas/qa-page-schema.js
+++ b/cypress/schemas/qa-page-schema.js
@@ -129,8 +129,7 @@ const qaPage100 = {
     mainEntity: {
       '@type': 'Question',
       name: 'How many ounces are there in a pound?',
-      text:
-        'I have taken up a new interest in baking and keep running across directions in ounces and pounds. I have to translate between them and was wondering how many ounces are in a pound?',
+      text: 'I have taken up a new interest in baking and keep running across directions in ounces and pounds. I have to translate between them and was wondering how many ounces are in a pound?',
       answerCount: 3,
       upvoteCount: 26,
       dateCreated: '2016-07-23T21:11Z',
@@ -152,8 +151,7 @@ const qaPage100 = {
       suggestedAnswer: [
         {
           '@type': 'Answer',
-          text:
-            'Are you looking for ounces or fluid ounces? If you are looking for fluid ounces there are 15.34 fluid ounces in a pound of water.',
+          text: 'Are you looking for ounces or fluid ounces? If you are looking for fluid ounces there are 15.34 fluid ounces in a pound of water.',
           dateCreated: '2016-11-02T21:11Z',
           upvoteCount: 42,
           url: 'https://example.com/question1#suggestedAnswer1',
@@ -164,8 +162,7 @@ const qaPage100 = {
         },
         {
           '@type': 'Answer',
-          text:
-            " I can't remember exactly, but I think 18 ounces in a lb. You might want to double check that.",
+          text: " I can't remember exactly, but I think 18 ounces in a lb. You might want to double check that.",
           dateCreated: '2016-11-06T21:11Z',
           upvoteCount: 0,
           url: 'https://example.com/question1#suggestedAnswer2',

--- a/e2e/pages/carousel-jsonld/event.tsx
+++ b/e2e/pages/carousel-jsonld/event.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { CarouselJsonLd } from '../../../';
+
+const eventData = [
+  {
+    name: 'Test Event 1',
+    url: 'http://example.com/event-1.html',
+    image: [
+      'https://example.com/photos/1x1/photo.jpg',
+      'https://example.com/photos/4x3/photo.jpg',
+      'https://example.com/photos/16x9/photo.jpg',
+    ],
+    offers: {
+      '@type': 'Offer',
+      price: 10,
+      priceCurrency: 'EUR',
+    },
+    aggregateRating: { ratingValue: 4.2, reviewCount: 20 },
+  },
+  {
+    name: 'Test Event 2',
+    url: 'http://example.com/event-2.html',
+    image: [
+      'https://example.com/photos/1x1/photo.jpg',
+      'https://example.com/photos/4x3/photo.jpg',
+      'https://example.com/photos/16x9/photo.jpg',
+    ],
+    offers: {
+      '@type': 'Offer',
+      price: 59.0,
+      priceCurrency: 'EUR',
+    },
+    aggregateRating: { ratingValue: 4.9, reviewCount: 652 },
+  },
+  {
+    name: 'Test Event 3',
+    url: 'http://example.com/event-3.html',
+    image: [
+      'https://example.com/photos/1x1/photo.jpg',
+      'https://example.com/photos/4x3/photo.jpg',
+      'https://example.com/photos/16x9/photo.jpg',
+    ],
+    offers: {
+      '@type': 'Offer',
+      price: 45.0,
+      priceCurrency: 'EUR',
+    },
+    aggregateRating: { ratingValue: 4.2, reviewCount: 690 },
+  },
+];
+
+const CarouselEvent = () => (
+  <>
+    <h1>Carousel Event JSON-LD</h1>
+    <CarouselJsonLd ofType="event" data={eventData} />
+  </>
+);
+
+export default CarouselEvent;

--- a/e2e/pages/carousel-jsonld/localBusiness.tsx
+++ b/e2e/pages/carousel-jsonld/localBusiness.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { CarouselJsonLd } from '../../../';
+
+const localBusinessData = [
+  {
+    name: 'Test Hotel',
+    url: 'http://example.com/hotel-1.html',
+    image: [
+      'https://example.com/photos/1x1/photo.jpg',
+      'https://example.com/photos/4x3/photo.jpg',
+      'https://example.com/photos/16x9/photo.jpg',
+    ],
+    priceRange: '$$$',
+    amenityFeature: {
+      '@type': 'LocationFeatureSpecification',
+      name: 'freeWifi',
+      value: true,
+    },
+    aggregateRating: { ratingValue: 4.8, reviewCount: 100 },
+  },
+  {
+    name: 'Test Restaurant',
+    url: 'http://example.com/restaurant-1.html',
+    image: [
+      'https://example.com/photos/1x1/photo.jpg',
+      'https://example.com/photos/4x3/photo.jpg',
+      'https://example.com/photos/16x9/photo.jpg',
+    ],
+    priceRange: '$$',
+    servesCuisine: 'Italian',
+    aggregateRating: { ratingValue: 4.5, reviewCount: 50 },
+  },
+  {
+    name: 'Test Vacation Rental',
+    url: 'http://example.com/vacation-1.html',
+    image: [
+      'https://example.com/photos/1x1/photo.jpg',
+      'https://example.com/photos/4x3/photo.jpg',
+      'https://example.com/photos/16x9/photo.jpg',
+    ],
+    priceRange: '$$',
+    amenityFeature: {
+      '@type': 'LocationFeatureSpecification',
+      name: 'instantBookable',
+      value: true,
+    },
+    aggregateRating: { ratingValue: 4.7, reviewCount: 827 },
+  },
+];
+
+const CarouselLocalBusiness = () => (
+  <>
+    <h1>Carousel LocalBusiness JSON-LD</h1>
+    <CarouselJsonLd ofType="localBusiness" data={localBusinessData} />
+  </>
+);
+
+export default CarouselLocalBusiness;

--- a/e2e/pages/carousel-jsonld/product.tsx
+++ b/e2e/pages/carousel-jsonld/product.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { CarouselJsonLd } from '../../../';
+
+const productData = [
+  {
+    name: 'Test Product 1',
+    url: 'http://example.com/product-1.html',
+    image: [
+      'https://example.com/photos/1x1/photo.jpg',
+      'https://example.com/photos/4x3/photo.jpg',
+      'https://example.com/photos/16x9/photo.jpg',
+    ],
+    offers: {
+      '@type': 'Offer',
+      price: 99.99,
+      priceCurrency: 'USD',
+    },
+    aggregateRating: { ratingValue: 4.5, reviewCount: 50 },
+  },
+  {
+    name: 'Test Product 2',
+    url: 'http://example.com/product-2.html',
+    image: [
+      'https://example.com/photos/1x1/photo.jpg',
+      'https://example.com/photos/4x3/photo.jpg',
+      'https://example.com/photos/16x9/photo.jpg',
+    ],
+    offers: {
+      '@type': 'AggregateOffer',
+      lowPrice: 45.0,
+      highPrice: 60.0,
+      priceCurrency: 'EUR',
+    },
+    aggregateRating: { ratingValue: 4.7, reviewCount: 827 },
+  },
+  {
+    name: 'Test Product 3',
+    url: 'http://example.com/product-3.html',
+    image: [
+      'https://example.com/photos/1x1/photo.jpg',
+      'https://example.com/photos/4x3/photo.jpg',
+      'https://example.com/photos/16x9/photo.jpg',
+    ],
+    offers: {
+      '@type': 'Offer',
+      price: 45.0,
+      priceCurrency: 'EUR',
+    },
+    aggregateRating: { ratingValue: 4.9, reviewCount: 1290 },
+  },
+];
+
+const CarouselProduct = () => (
+  <>
+    <h1>Carousel Product JSON-LD</h1>
+    <CarouselJsonLd ofType="product" data={productData} />
+  </>
+);
+
+export default CarouselProduct;

--- a/src/jsonld/__tests__/carousel.spec.tsx
+++ b/src/jsonld/__tests__/carousel.spec.tsx
@@ -1,0 +1,229 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import CarouselJsonLd, { CarouselJsonLdProps } from '../carousel';
+import { stringify } from '../../utils/toJson';
+
+describe('Carousel JSON-LD', () => {
+  it('renders Product carousel without aggregateRating', () => {
+    const props: CarouselJsonLdProps = {
+      ofType: 'product',
+      data: [
+        {
+          name: 'Product No Rating',
+          url: 'http://example.com/product-no-rating.html',
+          image: [
+            'https://example.com/photos/1x1/photo.jpg',
+            'https://example.com/photos/4x3/photo.jpg',
+            'https://example.com/photos/16x9/photo.jpg',
+          ],
+          offers: {
+            '@type': 'Offer',
+            price: 49.99,
+            priceCurrency: 'USD',
+          },
+        },
+      ],
+      scriptId: 'jsonld-carousel-product-norating',
+    };
+    render(<CarouselJsonLd {...props} />);
+    const script = screen.getByTestId('jsonld-carousel-product-norating');
+    const expected = {
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          item: {
+            '@type': 'Product',
+            name: 'Product No Rating',
+            url: 'http://example.com/product-no-rating.html',
+            image: [
+              'https://example.com/photos/1x1/photo.jpg',
+              'https://example.com/photos/4x3/photo.jpg',
+              'https://example.com/photos/16x9/photo.jpg',
+            ],
+            offers: {
+              '@type': 'Offer',
+              price: 49.99,
+              priceCurrency: 'USD',
+            },
+          },
+        },
+      ],
+    };
+    expect(JSON.parse(script.innerHTML)).toEqual(expected);
+  });
+  it('renders LocalBusiness carousel', () => {
+    const props: CarouselJsonLdProps = {
+      ofType: 'localBusiness',
+      data: [
+        {
+          name: 'Test Hotel',
+          url: 'http://example.com/hotel-1.html',
+          image: [
+            'https://example.com/photos/1x1/photo.jpg',
+            'https://example.com/photos/4x3/photo.jpg',
+            'https://example.com/photos/16x9/photo.jpg',
+          ],
+          priceRange: '$$$',
+          amenityFeature: {
+            '@type': 'LocationFeatureSpecification',
+            name: 'freeWifi',
+            value: true,
+          },
+          aggregateRating: { ratingValue: '4.8', reviewCount: '100' },
+        },
+      ],
+      scriptId: 'jsonld-carousel-localbusiness',
+    };
+    render(<CarouselJsonLd {...props} />);
+    const script = screen.getByTestId('jsonld-carousel-localbusiness');
+    const expected = {
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          item: {
+            '@type': 'LocalBusiness',
+            name: 'Test Hotel',
+            url: 'http://example.com/hotel-1.html',
+            image: [
+              'https://example.com/photos/1x1/photo.jpg',
+              'https://example.com/photos/4x3/photo.jpg',
+              'https://example.com/photos/16x9/photo.jpg',
+            ],
+            priceRange: '$$$',
+            amenityFeature: {
+              '@type': 'LocationFeatureSpecification',
+              name: 'freeWifi',
+              value: true,
+            },
+            aggregateRating: {
+              '@type': 'AggregateRating',
+              reviewCount: '100',
+              ratingValue: '4.8',
+            },
+          },
+        },
+      ],
+    };
+    expect(JSON.parse(script.innerHTML)).toEqual(expected);
+  });
+
+  it('renders Product carousel', () => {
+    const props: CarouselJsonLdProps = {
+      ofType: 'product',
+      data: [
+        {
+          name: 'Test Product',
+          url: 'http://example.com/product-1.html',
+          image: [
+            'https://example.com/photos/1x1/photo.jpg',
+            'https://example.com/photos/4x3/photo.jpg',
+            'https://example.com/photos/16x9/photo.jpg',
+          ],
+          offers: {
+            '@type': 'Offer',
+            price: 99.99,
+            priceCurrency: 'USD',
+          },
+          aggregateRating: { ratingValue: '4.5', reviewCount: '50' },
+        },
+      ],
+      scriptId: 'jsonld-carousel-product',
+    };
+    render(<CarouselJsonLd {...props} />);
+    const script = screen.getByTestId('jsonld-carousel-product');
+    const expected = {
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          item: {
+            '@type': 'Product',
+            name: 'Test Product',
+            url: 'http://example.com/product-1.html',
+            image: [
+              'https://example.com/photos/1x1/photo.jpg',
+              'https://example.com/photos/4x3/photo.jpg',
+              'https://example.com/photos/16x9/photo.jpg',
+            ],
+            offers: {
+              '@type': 'Offer',
+              price: 99.99,
+              priceCurrency: 'USD',
+            },
+            aggregateRating: {
+              '@type': 'AggregateRating',
+              reviewCount: '50',
+              ratingValue: '4.5',
+            },
+          },
+        },
+      ],
+    };
+    expect(JSON.parse(script.innerHTML)).toEqual(expected);
+  });
+
+  it('renders Event carousel', () => {
+    const props: CarouselJsonLdProps = {
+      ofType: 'event',
+      data: [
+        {
+          name: 'Test Event',
+          url: 'http://example.com/event-1.html',
+          image: [
+            'https://example.com/photos/1x1/photo.jpg',
+            'https://example.com/photos/4x3/photo.jpg',
+            'https://example.com/photos/16x9/photo.jpg',
+          ],
+          offers: {
+            '@type': 'Offer',
+            price: 10,
+            priceCurrency: 'EUR',
+          },
+          aggregateRating: { ratingValue: '4.2', reviewCount: '20' },
+        },
+      ],
+      scriptId: 'jsonld-carousel-event',
+    };
+    render(<CarouselJsonLd {...props} />);
+    const script = screen.getByTestId('jsonld-carousel-event');
+    const expected = {
+      '@context': 'https://schema.org',
+      '@type': 'ItemList',
+      itemListElement: [
+        {
+          '@type': 'ListItem',
+          position: 1,
+          item: {
+            '@type': 'Event',
+            name: 'Test Event',
+            url: 'http://example.com/event-1.html',
+            image: [
+              'https://example.com/photos/1x1/photo.jpg',
+              'https://example.com/photos/4x3/photo.jpg',
+              'https://example.com/photos/16x9/photo.jpg',
+            ],
+            offers: {
+              '@type': 'Offer',
+              price: 10,
+              priceCurrency: 'EUR',
+            },
+            aggregateRating: {
+              '@type': 'AggregateRating',
+              reviewCount: '20',
+              ratingValue: '4.2',
+            },
+          },
+        },
+      ],
+    };
+    expect(JSON.parse(script.innerHTML)).toEqual(expected);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,40 @@
+export interface LocalBusinessJsonLdProps {
+  name: string;
+  url: string;
+  image: string[];
+  priceRange?: string;
+  servesCuisine?: string;
+  amenityFeature?: {
+    '@type': 'LocationFeatureSpecification';
+    name: string;
+    value: string | boolean;
+  };
+  aggregateRating?: AggregateRating;
+}
+
+export interface ProductJsonLdProps {
+  name: string;
+  url: string;
+  image: string[];
+  offers?: Offers | Offers[];
+  aggregateOffer?: AggregateOffer;
+  aggregateRating?: AggregateRating;
+}
+
+export interface EventJsonLdProps {
+  name: string;
+  url: string;
+  image: string[];
+  offers?: {
+    '@type': 'Offer' | 'AggregateOffer';
+    price?: number;
+    priceCurrency?: string;
+    lowPrice?: number;
+    highPrice?: number;
+  };
+  aggregateRating?: AggregateRating;
+}
+
 export type OpeningHoursSpecification = {
   opens: string;
   closes: string;


### PR DESCRIPTION
## Description of Change(s):

Updated the Carousel component to support the latest beta Google Carousels structured data.

- LocalBusiness
- Product
- Event
- improved Custom types. Now is allowed to inject any params when using custom

## Reference:

[Google Carousels Beta Documentation](https://developers.google.com/search/docs/appearance/structured-data/carousels-beta)

---

[x] Updated the documentation
[x] Unit/Cypress test covering all cases