### PR TITLE
docs: Add JSDoc comment to type guard function

### DIFF
--- a/.changeset/tiny-docs-improvement.md
+++ b/.changeset/tiny-docs-improvement.md
@@ -1,0 +1,5 @@
+---
+"next-seo": patch
+---
+
+Add JSDoc comment to internal type guard function

--- a/src/utils/stringify.ts
+++ b/src/utils/stringify.ts
@@ -38,7 +38,10 @@ const safeJsonLdReplacer: JsonReplacer = (() => {
   };
 })();
 
-// Utility: Assert never
+/**
+ * Type guard to ensure exhaustive type checking.
+ * @internal
+ */
 function isNever(_: never): void {}
 
 /**


### PR DESCRIPTION
## Summary

Add JSDoc documentation to the internal `isNever` type guard function in the stringify utility to improve code readability and maintainability.

## Changes

- Added JSDoc comment explaining the purpose of the `isNever` function
- Marked the function as `@internal` to indicate it's not part of the public API
- Created patch changeset for this documentation improvement

## Purpose

This is a **test release** to verify the complete release workflow:

1. ✅ PR checks (CI workflow runs)
2. ✅ Changeset validation passes
3. ✅ Branch protection with "All CI Checks" status
4. ⏳ Merge triggers Version Packages PR
5. ⏳ Merging Version Packages PR triggers NPM publish
6. ⏳ GitHub release created automatically
7. ⏳ Git tag pushed successfully

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation (improvement to code comments or documentation)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)