### PR TITLE
Add nonce prop to all JSON-LD components for CSP compliance

### DIFF
--- a/src/components/AggregateRatingJsonLd.tsx
+++ b/src/components/AggregateRatingJsonLd.tsx
@@ -5,6 +5,7 @@ import { processItemReviewed } from "~/utils/processors";
 export default function AggregateRatingJsonLd({
   scriptId,
   scriptKey,
+  nonce,
   itemReviewed,
   ratingValue,
   ratingCount,
@@ -39,6 +40,7 @@ export default function AggregateRatingJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "aggregaterating-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/ArticleJsonLd.test.tsx
+++ b/src/components/ArticleJsonLd.test.tsx
@@ -419,6 +419,37 @@ describe("ArticleJsonLd", () => {
     });
   });
 
+  it("renders nonce attribute on script element when provided", () => {
+    const { container } = render(
+      <ArticleJsonLd
+        headline="Test Article"
+        datePublished="2024-01-01T00:00:00.000Z"
+        nonce="abc123"
+      />,
+    );
+
+    const script = container.querySelector(
+      'script[type="application/ld+json"]',
+    );
+    expect(script).toBeTruthy();
+    expect(script!.getAttribute("nonce")).toBe("abc123");
+  });
+
+  it("does not render nonce attribute when not provided", () => {
+    const { container } = render(
+      <ArticleJsonLd
+        headline="Test Article"
+        datePublished="2024-01-01T00:00:00.000Z"
+      />,
+    );
+
+    const script = container.querySelector(
+      'script[type="application/ld+json"]',
+    );
+    expect(script).toBeTruthy();
+    expect(script!.getAttribute("nonce")).toBeNull();
+  });
+
   it("handles Person publisher with @type", () => {
     const { container } = render(
       <ArticleJsonLd

--- a/src/components/ArticleJsonLd.tsx
+++ b/src/components/ArticleJsonLd.tsx
@@ -11,6 +11,7 @@ export default function ArticleJsonLd({
   type = "Article",
   scriptId,
   scriptKey,
+  nonce,
   headline,
   url,
   author,
@@ -54,6 +55,7 @@ export default function ArticleJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || `article-jsonld-${type}`}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/BreadcrumbJsonLd.tsx
+++ b/src/components/BreadcrumbJsonLd.tsx
@@ -3,7 +3,7 @@ import type { BreadcrumbJsonLdProps } from "~/types/breadcrumb.types";
 import { processBreadcrumbItem } from "~/utils/processors";
 
 export default function BreadcrumbJsonLd(props: BreadcrumbJsonLdProps) {
-  const { scriptId, scriptKey } = props;
+  const { scriptId, scriptKey, nonce } = props;
 
   // Handle single trail vs multiple trails
   const hasMultipleTrails = "multipleTrails" in props;
@@ -23,6 +23,7 @@ export default function BreadcrumbJsonLd(props: BreadcrumbJsonLdProps) {
         data={data}
         id={scriptId}
         scriptKey={scriptKey || "breadcrumb-jsonld-multiple"}
+        nonce={nonce}
       />
     );
   } else {
@@ -40,6 +41,7 @@ export default function BreadcrumbJsonLd(props: BreadcrumbJsonLdProps) {
         data={data}
         id={scriptId}
         scriptKey={scriptKey || "breadcrumb-jsonld"}
+        nonce={nonce}
       />
     );
   }

--- a/src/components/CarouselJsonLd.tsx
+++ b/src/components/CarouselJsonLd.tsx
@@ -191,7 +191,7 @@ function processRestaurantItem(
 }
 
 export default function CarouselJsonLd(props: CarouselJsonLdProps) {
-  const { scriptId, scriptKey } = props;
+  const { scriptId, scriptKey, nonce } = props;
 
   let itemListElement: CarouselListItem[];
 
@@ -239,6 +239,7 @@ export default function CarouselJsonLd(props: CarouselJsonLdProps) {
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "carousel-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/ClaimReviewJsonLd.tsx
+++ b/src/components/ClaimReviewJsonLd.tsx
@@ -9,6 +9,7 @@ import {
 export default function ClaimReviewJsonLd({
   scriptId,
   scriptKey,
+  nonce,
   claimReviewed,
   reviewRating,
   url,
@@ -30,6 +31,7 @@ export default function ClaimReviewJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "claimreview-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/CourseJsonLd.tsx
+++ b/src/components/CourseJsonLd.tsx
@@ -46,7 +46,7 @@ function processCourseItem(
 }
 
 export default function CourseJsonLd(props: CourseJsonLdProps) {
-  const { scriptId, scriptKey } = props;
+  const { scriptId, scriptKey, nonce } = props;
 
   // Single course pattern
   if (!("type" in props) || props.type === "single") {
@@ -64,6 +64,7 @@ export default function CourseJsonLd(props: CourseJsonLdProps) {
         data={data}
         id={scriptId}
         scriptKey={scriptKey || "course-jsonld"}
+        nonce={nonce}
       />
     );
   }
@@ -97,6 +98,7 @@ export default function CourseJsonLd(props: CourseJsonLdProps) {
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "course-list-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/CreativeWorkJsonLd.tsx
+++ b/src/components/CreativeWorkJsonLd.tsx
@@ -12,6 +12,7 @@ export default function CreativeWorkJsonLd({
   type = "CreativeWork",
   scriptId,
   scriptKey,
+  nonce,
   headline,
   name,
   url,
@@ -79,6 +80,7 @@ export default function CreativeWorkJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || `creativework-jsonld-${type.toLowerCase()}`}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/DatasetJsonLd.tsx
+++ b/src/components/DatasetJsonLd.tsx
@@ -13,6 +13,7 @@ import {
 export default function DatasetJsonLd({
   scriptId,
   scriptKey,
+  nonce,
   name,
   description,
   url,
@@ -86,6 +87,7 @@ export default function DatasetJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "dataset-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/DiscussionForumPostingJsonLd.tsx
+++ b/src/components/DiscussionForumPostingJsonLd.tsx
@@ -14,6 +14,7 @@ export default function DiscussionForumPostingJsonLd({
   type = "DiscussionForumPosting",
   scriptId,
   scriptKey,
+  nonce,
   headline,
   text,
   image,
@@ -65,6 +66,7 @@ export default function DiscussionForumPostingJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || `${type.toLowerCase()}-jsonld`}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/EmployerAggregateRatingJsonLd.tsx
+++ b/src/components/EmployerAggregateRatingJsonLd.tsx
@@ -63,6 +63,7 @@ function processEmployerItemReviewed(
 export default function EmployerAggregateRatingJsonLd({
   scriptId,
   scriptKey,
+  nonce,
   itemReviewed,
   ratingValue,
   ratingCount,
@@ -93,6 +94,7 @@ export default function EmployerAggregateRatingJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "employer-aggregate-rating-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/EventJsonLd.tsx
+++ b/src/components/EventJsonLd.tsx
@@ -11,6 +11,7 @@ import {
 export default function EventJsonLd({
   scriptId,
   scriptKey,
+  nonce,
   name,
   startDate,
   location,
@@ -60,6 +61,7 @@ export default function EventJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "event-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/FAQJsonLd.tsx
+++ b/src/components/FAQJsonLd.tsx
@@ -64,6 +64,7 @@ export default function FAQJsonLd({
   questions,
   scriptId,
   scriptKey,
+  nonce,
 }: FAQJsonLdProps) {
   const data = {
     "@context": "https://schema.org",
@@ -76,6 +77,7 @@ export default function FAQJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "faq-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/HowToJsonLd.tsx
+++ b/src/components/HowToJsonLd.tsx
@@ -13,6 +13,7 @@ import {
 export default function HowToJsonLd({
   scriptId,
   scriptKey,
+  nonce,
   name,
   description,
   image,
@@ -64,6 +65,7 @@ export default function HowToJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "howto-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/ImageJsonLd.tsx
+++ b/src/components/ImageJsonLd.tsx
@@ -5,6 +5,7 @@ import { processAuthor } from "~/utils/processors";
 export default function ImageJsonLd({
   scriptId,
   scriptKey,
+  nonce,
   ...props
 }: ImageJsonLdProps) {
   // Helper function to process a single image
@@ -55,6 +56,7 @@ export default function ImageJsonLd({
       }}
       id={scriptId}
       scriptKey={scriptKey || "image-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/JobPostingJsonLd.tsx
+++ b/src/components/JobPostingJsonLd.tsx
@@ -13,6 +13,7 @@ import {
 export default function JobPostingJsonLd({
   scriptId,
   scriptKey,
+  nonce,
   title,
   description,
   datePosted,
@@ -86,6 +87,7 @@ export default function JobPostingJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "jobposting-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/LocalBusinessJsonLd.tsx
+++ b/src/components/LocalBusinessJsonLd.tsx
@@ -87,6 +87,7 @@ export default function LocalBusinessJsonLd({
   type = "LocalBusiness",
   scriptId,
   scriptKey,
+  nonce,
   name,
   address,
   url,
@@ -179,6 +180,7 @@ export default function LocalBusinessJsonLd({
         scriptKey ||
         `localbusiness-jsonld-${Array.isArray(type) ? type.join("-") : type}`
       }
+      nonce={nonce}
     />
   );
 }

--- a/src/components/MerchantReturnPolicyJsonLd.tsx
+++ b/src/components/MerchantReturnPolicyJsonLd.tsx
@@ -9,6 +9,7 @@ import {
 export default function MerchantReturnPolicyJsonLd({
   scriptId,
   scriptKey,
+  nonce,
   applicableCountry,
   returnPolicyCountry,
   returnPolicyCategory,
@@ -110,6 +111,7 @@ export default function MerchantReturnPolicyJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "merchant-return-policy-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/MovieCarouselJsonLd.tsx
+++ b/src/components/MovieCarouselJsonLd.tsx
@@ -58,7 +58,7 @@ function processMovieItem(
 }
 
 export default function MovieCarouselJsonLd(props: MovieCarouselJsonLdProps) {
-  const { scriptId, scriptKey } = props;
+  const { scriptId, scriptKey, nonce } = props;
 
   // Determine if this is summary page or all-in-one page pattern
   const isSummaryPage = "urls" in props;
@@ -88,6 +88,7 @@ export default function MovieCarouselJsonLd(props: MovieCarouselJsonLdProps) {
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "movie-carousel-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/OrganizationJsonLd.tsx
+++ b/src/components/OrganizationJsonLd.tsx
@@ -16,6 +16,7 @@ export default function OrganizationJsonLd(props: OrganizationJsonLdProps) {
     type = "Organization",
     scriptId,
     scriptKey,
+    nonce,
     name,
     url,
     logo,
@@ -103,6 +104,7 @@ export default function OrganizationJsonLd(props: OrganizationJsonLdProps) {
       data={data}
       id={scriptId}
       scriptKey={scriptKey || `organization-jsonld-${type}`}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/ProductJsonLd.tsx
+++ b/src/components/ProductJsonLd.tsx
@@ -17,7 +17,7 @@ import {
 } from "~/utils/processors";
 
 export default function ProductJsonLd(props: ProductJsonLdProps) {
-  const { scriptId, scriptKey, ...rest } = props;
+  const { scriptId, scriptKey, nonce, ...rest } = props;
 
   // Determine if this is a ProductGroup or Product
   const isProductGroup =
@@ -257,6 +257,7 @@ export default function ProductJsonLd(props: ProductJsonLdProps) {
       scriptKey={
         scriptKey || (isProductGroup ? "productgroup-jsonld" : "product-jsonld")
       }
+      nonce={nonce}
     />
   );
 }

--- a/src/components/ProfilePageJsonLd.tsx
+++ b/src/components/ProfilePageJsonLd.tsx
@@ -8,6 +8,7 @@ export default function ProfilePageJsonLd({
   dateModified,
   scriptId,
   scriptKey,
+  nonce,
 }: ProfilePageJsonLdProps) {
   // Process mainEntity - it can be a string, Person, Organization, or objects without @type
   const processedMainEntity = processAuthor(mainEntity);
@@ -46,6 +47,7 @@ export default function ProfilePageJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "profile-page-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/QuizJsonLd.tsx
+++ b/src/components/QuizJsonLd.tsx
@@ -98,6 +98,7 @@ export default function QuizJsonLd({
   educationalAlignment,
   scriptId,
   scriptKey,
+  nonce,
 }: QuizJsonLdProps) {
   const data = {
     "@context": "https://schema.org/",
@@ -118,6 +119,7 @@ export default function QuizJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "quiz-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/RecipeJsonLd.tsx
+++ b/src/components/RecipeJsonLd.tsx
@@ -12,6 +12,7 @@ import {
 export default function RecipeJsonLd({
   scriptId,
   scriptKey,
+  nonce,
   name,
   image,
   description,
@@ -65,6 +66,7 @@ export default function RecipeJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "recipe-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/ReviewJsonLd.tsx
+++ b/src/components/ReviewJsonLd.tsx
@@ -10,6 +10,7 @@ import {
 export default function ReviewJsonLd({
   scriptId,
   scriptKey,
+  nonce,
   author,
   reviewRating,
   itemReviewed,
@@ -56,6 +57,7 @@ export default function ReviewJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "review-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/SoftwareApplicationJsonLd.tsx
+++ b/src/components/SoftwareApplicationJsonLd.tsx
@@ -19,6 +19,7 @@ export default function SoftwareApplicationJsonLd({
   type = "SoftwareApplication",
   scriptId,
   scriptKey,
+  nonce,
   name,
   description,
   url,
@@ -140,6 +141,7 @@ export default function SoftwareApplicationJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || `software-application-jsonld-${typeKey}`}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/VacationRentalJsonLd.tsx
+++ b/src/components/VacationRentalJsonLd.tsx
@@ -12,6 +12,7 @@ import {
 export default function VacationRentalJsonLd({
   scriptId,
   scriptKey,
+  nonce,
   containsPlace,
   identifier,
   image,
@@ -73,6 +74,7 @@ export default function VacationRentalJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || "vacationrental-jsonld"}
+      nonce={nonce}
     />
   );
 }

--- a/src/components/VideoJsonLd.tsx
+++ b/src/components/VideoJsonLd.tsx
@@ -14,6 +14,7 @@ export default function VideoJsonLd({
   type = "VideoObject",
   scriptId,
   scriptKey,
+  nonce,
   name,
   description,
   thumbnailUrl,
@@ -85,6 +86,7 @@ export default function VideoJsonLd({
       data={data}
       id={scriptId}
       scriptKey={scriptKey || `video-jsonld-${type}`}
+      nonce={nonce}
     />
   );
 }

--- a/src/core/JsonLdScript.tsx
+++ b/src/core/JsonLdScript.tsx
@@ -4,12 +4,14 @@ interface JsonLdScriptProps<T = Record<string, unknown>> {
   data: T;
   id?: string;
   scriptKey: string; // For React key
+  nonce?: string;
 }
 
 export function JsonLdScript<T = Record<string, unknown>>({
   data,
   id,
   scriptKey,
+  nonce,
 }: JsonLdScriptProps<T>): React.JSX.Element | null {
   if (data === null || data === undefined) {
     // Explicitly check for null/undefined
@@ -25,6 +27,7 @@ export function JsonLdScript<T = Record<string, unknown>>({
       data-testid={id}
       dangerouslySetInnerHTML={{ __html: jsonString }}
       key={scriptKey}
+      nonce={nonce}
     />
   );
 }

--- a/src/types/article.types.ts
+++ b/src/types/article.types.ts
@@ -57,4 +57,5 @@ export type ArticleJsonLdProps = (
   type?: "Article" | "NewsArticle" | "BlogPosting" | "Blog";
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };

--- a/src/types/breadcrumb.types.ts
+++ b/src/types/breadcrumb.types.ts
@@ -27,9 +27,11 @@ export type BreadcrumbJsonLdProps =
       items: BreadcrumbListItem[];
       scriptId?: string;
       scriptKey?: string;
+      nonce?: string;
     }
   | {
       multipleTrails: BreadcrumbListItem[][];
       scriptId?: string;
       scriptKey?: string;
+      nonce?: string;
     };

--- a/src/types/carousel.types.ts
+++ b/src/types/carousel.types.ts
@@ -91,6 +91,7 @@ export type RestaurantItem = Omit<
 interface CarouselJsonLdBaseProps {
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 }
 
 // Summary page pattern props

--- a/src/types/claimreview.types.ts
+++ b/src/types/claimreview.types.ts
@@ -48,4 +48,5 @@ export interface ClaimReview {
 export type ClaimReviewJsonLdProps = Omit<ClaimReview, "@type"> & {
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };

--- a/src/types/course.types.ts
+++ b/src/types/course.types.ts
@@ -39,6 +39,7 @@ export type SummaryPageItem = string | { url: string; position?: number };
 interface CourseJsonLdBaseProps {
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 }
 
 // Single course props

--- a/src/types/creativework.types.ts
+++ b/src/types/creativework.types.ts
@@ -162,4 +162,5 @@ export type CreativeWorkJsonLdProps = {
     | "WebPage";
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };

--- a/src/types/dataset.types.ts
+++ b/src/types/dataset.types.ts
@@ -99,4 +99,5 @@ export interface Dataset {
 export type DatasetJsonLdProps = Omit<Dataset, "@type"> & {
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };

--- a/src/types/discussionforum.types.ts
+++ b/src/types/discussionforum.types.ts
@@ -90,4 +90,5 @@ export type DiscussionForumPostingJsonLdProps = (
   type?: "DiscussionForumPosting" | "SocialMediaPosting";
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };

--- a/src/types/employer-aggregate-rating.types.ts
+++ b/src/types/employer-aggregate-rating.types.ts
@@ -19,4 +19,5 @@ export type EmployerAggregateRatingJsonLdProps = Omit<
   itemReviewed: string | Organization | Omit<Organization, "@type">;
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };

--- a/src/types/event.types.ts
+++ b/src/types/event.types.ts
@@ -80,4 +80,5 @@ export interface Event extends EventBase {
 export type EventJsonLdProps = Omit<Event, "@type"> & {
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };

--- a/src/types/faq.types.ts
+++ b/src/types/faq.types.ts
@@ -38,4 +38,5 @@ export interface FAQJsonLdProps {
   questions: QuestionInput[];
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 }

--- a/src/types/howto.types.ts
+++ b/src/types/howto.types.ts
@@ -154,4 +154,5 @@ export interface HowTo {
 export type HowToJsonLdProps = Omit<HowTo, "@type"> & {
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };

--- a/src/types/image.types.ts
+++ b/src/types/image.types.ts
@@ -19,6 +19,7 @@ export interface ImageMetadata extends ImageBase {
 export type ImageJsonLdProps = {
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 } & (
   | Omit<ImageMetadata, "@type">
   | {

--- a/src/types/jobposting.types.ts
+++ b/src/types/jobposting.types.ts
@@ -112,4 +112,5 @@ export interface JobPosting extends JobPostingBase {
 export type JobPostingJsonLdProps = Omit<JobPostingBase, "@type"> & {
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };

--- a/src/types/localbusiness.types.ts
+++ b/src/types/localbusiness.types.ts
@@ -94,6 +94,7 @@ export type LocalBusinessJsonLdProps = Omit<LocalBusinessBase, "department"> & {
   type?: string | string[];
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
   department?:
     | (Omit<LocalBusinessBase, "department"> & { type?: string | string[] })
     | (Omit<LocalBusinessBase, "department"> & { type?: string | string[] })[];

--- a/src/types/merchantreturnpolicy.types.ts
+++ b/src/types/merchantreturnpolicy.types.ts
@@ -7,4 +7,5 @@ export type MerchantReturnPolicyJsonLdProps = Omit<
 > & {
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };

--- a/src/types/movie-carousel.types.ts
+++ b/src/types/movie-carousel.types.ts
@@ -51,6 +51,7 @@ export type SummaryPageItem = string | { url: string; position?: number };
 export type MovieCarouselJsonLdProps = {
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 } & (
   | {
       // Summary page pattern - just URLs

--- a/src/types/organization.types.ts
+++ b/src/types/organization.types.ts
@@ -29,4 +29,5 @@ export type OrganizationJsonLdProps = (
   type?: "Organization" | "OnlineStore";
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };

--- a/src/types/product.types.ts
+++ b/src/types/product.types.ts
@@ -299,4 +299,5 @@ export type ProductJsonLdProps = (
 ) & {
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };

--- a/src/types/profile.types.ts
+++ b/src/types/profile.types.ts
@@ -22,4 +22,5 @@ export type ProfilePageJsonLdProps = {
   dateModified?: string;
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };

--- a/src/types/quiz.types.ts
+++ b/src/types/quiz.types.ts
@@ -56,4 +56,5 @@ export interface QuizJsonLdProps {
   }>;
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 }

--- a/src/types/recipe.types.ts
+++ b/src/types/recipe.types.ts
@@ -74,4 +74,5 @@ export interface Recipe {
 export type RecipeJsonLdProps = Omit<Recipe, "@type"> & {
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };

--- a/src/types/review.types.ts
+++ b/src/types/review.types.ts
@@ -27,6 +27,7 @@ export interface ReviewJsonLdProps {
   // JSON-LD plumbing
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 
   // Required per Google Review
   author: Author;
@@ -56,6 +57,7 @@ export interface ReviewJsonLdProps {
 export interface AggregateRatingJsonLdProps {
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 
   itemReviewed: ItemReviewedInput;
   ratingValue: number | string;

--- a/src/types/softwareApplication.types.ts
+++ b/src/types/softwareApplication.types.ts
@@ -219,4 +219,5 @@ export type SoftwareApplicationJsonLdProps = (
   type?: ApplicationType | VideoGameCoTyped;
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };

--- a/src/types/vacationrental.types.ts
+++ b/src/types/vacationrental.types.ts
@@ -46,4 +46,5 @@ export interface VacationRental extends VacationRentalBase {
 export type VacationRentalJsonLdProps = Omit<VacationRentalBase, "@type"> & {
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };

--- a/src/types/video.types.ts
+++ b/src/types/video.types.ts
@@ -82,4 +82,5 @@ export type VideoJsonLdProps = Omit<VideoObject, "@type"> & {
   type?: "VideoObject";
   scriptId?: string;
   scriptKey?: string;
+  nonce?: string;
 };


### PR DESCRIPTION
## Summary

- Adds optional `nonce` prop to all 28 JSON-LD components, enabling Content Security Policy (CSP) compliance
- Propagates `nonce` through the core `JsonLdScript` component to the rendered `<script type="application/ld+json">` tags
- Includes unit test coverage for nonce presence and absence on `ArticleJsonLd`

## Motivation

Sites using strict CSP headers (`script-src 'nonce-...'`) cannot render inline scripts without a valid nonce attribute. This change lets users pass their CSP nonce to all next-seo JSON-LD components.

## Changes

- `src/core/JsonLdScript.tsx` — accept and render `nonce` on the script element
- All 27 type definition files — add `nonce?: string` to component props
- All 28 component files — destructure and forward `nonce` to `JsonLdScript`
- `ArticleJsonLd.test.tsx` — two new tests for nonce rendering

## Test plan

- [x] `pnpm test:unit` passes
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds