### PR TITLE
chore(package): add license field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "next-seo",
   "version": "7.2.0",
   "description": "SEO plugin for Next.js projects",
+  "license": "MIT",
   "sideEffects": false,
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi Gary 👋

## Problem

Since the v7 major update, the `license` field is missing from `package.json`.
This breaks static analysis tools that scan dependencies — including the one we use at my company (depcheck).

## Solution

This PR adds the `license` field back to `package.json`.

Let me know what you think!