### PR TITLE
fix: add license, bugs, and homepage metadata to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,5 +89,10 @@
   "peerDependencies": {
     "next": ">=13.4.0",
     "react": ">=18.2.0"
-  }
+  },
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/garmeeh/next-seo/issues"
+  },
+  "homepage": "https://github.com/garmeeh/next-seo#readme"
 }


### PR DESCRIPTION
## Summary
The published npm package `next-seo@7.2.0` is missing `license`, `bugs`, and `homepage` fields in its `package.json`.

## Changes
- Added `license: "MIT"` — the repository already contains both `LICENSE` and `LICENSE.md` files
- Added `bugs` field pointing to the GitHub issues tracker
- Added `homepage` field pointing to the repository README

## Verification
- `npm view next-seo license bugs homepage --json` — all three return nothing
- No dependencies, runtime code, or build configuration affected